### PR TITLE
Fixed bower name & version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "//": "experimental bower support",
-  "name": "auth0-js",
-  "version": "2.0.5",
+  "name": "auth0.js",
   "main": "lib/index.js",
   "dependencies": {
     "qs": "https://github.com/jfromaniello/node-querystring.git",


### PR DESCRIPTION
Fixed: This package is published as `auth0.js` so the name `auth0-js` was incorrect (and causing warnings in `bower install`).
Fixed: Version was out of sync with the git tags and also with `package.json`. This is an [optional property](https://github.com/bower/bower.json-spec/blob/master/README.md) and safe to remove, as it defaults to the git tag.
