### PR TITLE
Add prefix to all jsonp requests to avoid bug when learnboost/jsonp 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var xtend             = require('xtend');
 var reqwest           = require('reqwest');
 
 var jsonp             = require('jsonp');
+var jsonpOpts         = { param: 'cbx', timeout: 15000, prefix: '__auth0jp' };
 
 var use_jsonp         = require('./use_jsonp');
 var LoginError        = require('./LoginError');
@@ -67,10 +68,7 @@ Auth0.prototype._getUserInfo = function (profile, id_token, callback) {
     };
 
     if (this._useJSONP) {
-      return jsonp(url + qs.stringify({id_token: id_token}), {
-        param: 'cbx',
-        timeout: 15000
-      }, function (err, resp) {
+      return jsonp(url + qs.stringify({id_token: id_token}), jsonpOpts, function (err, resp) {
         if (err) {
           return fail(0, err.toString());
         }
@@ -115,10 +113,7 @@ Auth0.prototype.validateUser = function (options, callback) {
     });
 
   if (this._useJSONP) {
-    return jsonp(endpoint + '?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp(endpoint + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         return callback(err);
       }
@@ -225,10 +220,7 @@ Auth0.prototype.signup = function (options, callback) {
   }
 
   if (this._useJSONP) {
-    return jsonp('https://' + this._domain + '/dbconnections/signup?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp('https://' + this._domain + '/dbconnections/signup?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         return fail(0, err);
       }
@@ -267,10 +259,7 @@ Auth0.prototype.changePassword = function (options, callback) {
   }
 
   if (this._useJSONP) {
-    return jsonp('https://' + this._domain + '/dbconnections/change_password?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp('https://' + this._domain + '/dbconnections/change_password?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         return fail(0, err);
       }
@@ -515,10 +504,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
   }
 
   if (this._useJSONP) {
-    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         return callback(err);
       }
@@ -588,10 +574,7 @@ Auth0.prototype.loginWithUsernamePassword = function (options, callback) {
   var endpoint = '/usernamepassword/login';
 
   if (this._useJSONP) {
-    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         if (popup) popup.close();
         return callback(err);
@@ -651,10 +634,7 @@ Auth0.prototype.getDelegationToken = function (targetClientId, id_token, options
   var endpoint = '/delegation';
 
   if (this._useJSONP) {
-    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), {
-      param: 'cbx',
-      timeout: 15000
-    }, function (err, resp) {
+    return jsonp('https://' + this._domain + endpoint + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
         return callback(err);
       }
@@ -713,19 +693,13 @@ Auth0.prototype.getSSOData = function (withActiveDirectories, callback) {
     url += '?' + qs.stringify({ldaps: 1, client_id: this._clientID});
   }
 
-  return jsonp(url, {
-    param: 'cbx',
-    timeout: 15000
-  }, function (err, resp) {
+  return jsonp(url, jsonpOpts, function (err, resp) {
     callback(null, err ? {} : resp); // Always return OK, regardless of any errors
   });
 };
 
 Auth0.prototype.getConnections = function (callback) {
-  return jsonp('https://' + this._domain + '/public/api/' + this._clientID + '/connections', {
-    param: 'cbx',
-    timeout: 15000
-  }, callback);
+  return jsonp('https://' + this._domain + '/public/api/' + this._clientID + '/connections', jsonpOpts, callback);
 };
 
 module.exports = Auth0;


### PR DESCRIPTION
Add prefix to all jsonp requests to avoid bug when learnboost/jsonp  is used in site including this lib.

Not using a prefix for requests may cause unexpected behaviours and responses to cross handlers.
