### PR TITLE
Explicitly refer to delegation endpoint in missing token error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -953,7 +953,7 @@ Auth0.prototype.getDelegationToken = function (options, callback) {
   options = options || {};
 
   if (!options.id_token && !options.refresh_token ) {
-    throw new Error("You must send either an id_token or a refresh_token to do this call");
+    throw new Error("You must send either an id_token or a refresh_token to get a delegation token.");
   }
 
   var query = xtend({

--- a/test/tests.js
+++ b/test/tests.js
@@ -435,7 +435,7 @@ describe('Auth0', function () {
     it('should throw error if no token is sent', function () {
       expect(function () {
         auth0.getDelegationToken(null, function(err, delegation) {});
-      }).to.throwError(/You must send either an id_token or a refresh_token to do this call/);
+      }).to.throwError(/You must send either an id_token or a refresh_token to get a delegation token./);
     });
 
 


### PR DESCRIPTION
When looking at error messages in the browser console, it's not clear that "this call" refers to. This commit makes it explicit.
