### PR TITLE
Multiple fixes for sso dbconn popup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -877,7 +877,8 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
         username:   options.username,
         password:   options.password,
         connection: options.connection,
-        state:      options.state
+        state:      options.state,
+        scope:      options.scope
       }
     }
   }, function (err, result) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1064,6 +1064,10 @@ Auth0.prototype._buildPopupWindow = function (options, url) {
 
   var self = this;
 
+  if (!this._current_popup) {
+    throw new Error('Popup window cannot not been created. Disable popup blocker or make sure to call Auth0 login or singup on an UI event.');
+  }
+
   this._current_popup.kill = function () {
     this.close();
     delete self._current_popup;

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,12 +79,6 @@ function Auth0 (options) {
     facebook: this._phonegapFacebookLogin
   };
   this._useCordovaSocialPlugins = false || options.useCordovaSocialPlugins;
-
-  // TODO Change this to a property named 'disableSSO' for consistency.
-  // By default, options.sso is true
-  if (!checkIfSet(options, 'sso')) {
-    options.sso = true;
-  }
 }
 
 /**
@@ -381,6 +375,12 @@ Auth0.prototype.signup = function (options, callback) {
 
   this._configureOfflineMode(query);
 
+  // TODO Change this to a property named 'disableSSO' for consistency.
+  // By default, options.sso is true
+  if (!checkIfSet(options, 'sso')) {
+    options.sso = true;
+  }
+
   var popup;
 
   if (options.popup  && !this._getCallbackOnLocationHash(options)) {
@@ -541,6 +541,12 @@ Auth0.prototype._buildAuthorizationParameters = function(args, blacklist) {
  */
 
 Auth0.prototype.login = Auth0.prototype.signin = function (options, callback) {
+
+  // TODO Change this to a property named 'disableSSO' for consistency.
+  // By default, options.sso is true
+  if (!checkIfSet(options, 'sso')) {
+    options.sso = true;
+  }
 
   if (typeof options.username !== 'undefined' ||
       typeof options.email !== 'undefined') {


### PR DESCRIPTION
* `sso: true` default flag was not working.
* `options.scope` argument was not being sent when `sso: true`, `popup: true` and Database connection.
* Added error when popup blocker prevented opening new windows.