### PR TITLE
Adding detection of connection refused/timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,33 +83,34 @@ function checkIfSet(obj, key) {
 
 function handleRequestError(err, callback) {
   var er = err;
-  var ieVersion = isInternetExplorer();
+  var isAffectedIEVersion = isInternetExplorer() === 10 || isInternetExplorer() === 11;
+  var zeroStatus = (!er.status || er.status === 0);
 
   var onLine = !!window.navigator.onLine;
 
-  // http://stackoverflow.com/questions/23229723/ie-10-11-cors-status-0
-  // XXX IE10 when a request fails in CORS returns status code 0
-  // See: http://caniuse.com/#search=navigator.onLine
-  if (er.status === 0 && (ieVersion === 10 || ieVersion === 11) ) {
-    er = {};
-    er.status = 401;
-    er.responseText = {
-      code: 'invalid_user_password'
-    };
   // Request failed because we are offline.
-  } else if ((!er.status || er.status === 0) && !onLine ) {
+  if (zeroStatus && !onLine ) {
     er = {};
     er.status = 0;
     er.responseText = {
       code: 'offline'
     };
+  // http://stackoverflow.com/questions/23229723/ie-10-11-cors-status-0
+  // XXX IE10 when a request fails in CORS returns status code 0
+  // See: http://caniuse.com/#search=navigator.onLine
+  } else if (zeroStatus && isAffectedIEVersion) {
+    er = {};
+    er.status = 401;
+    er.responseText = {
+      code: 'invalid_user_password'
+    };
   // If not IE10/11 and not offline it means that Auth0 host is unreachable:
   // Connection Timeout or Connection Refused.
-  } else if (er.status === 0) {
+  } else if (zeroStatus) {
     er = {};
     er.status = 0;
     er.responseText = {
-      code: 'connection_refused'
+      code: 'connection_refused_timeout'
     };
   } else {
     er.responseText = err;
@@ -1307,13 +1308,21 @@ Auth0.prototype.getDelegationToken = function (options, callback) {
       }
       catch (e) {
         var er = err;
-        var ieVersion = isInternetExplorer();
+        var isAffectedIEVersion = isInternetExplorer() === 10 || isInternetExplorer() === 11;
+        var zeroStatus = (!er.status || er.status === 0);
 
+        // Request failed because we are offline.
+        // See: http://caniuse.com/#search=navigator.onLine
+        if (zeroStatus && !window.navigator.onLine) {
+          er = {};
+          er.status = 0;
+          er.responseText = {
+            code: 'offline'
+          };
         // http://stackoverflow.com/questions/23229723/ie-10-11-cors-status-0
         // XXX IE10 when a request fails in CORS returns status code 0
         // XXX This is not handled by handleRequestError as the errors are different
-        // See: http://caniuse.com/#search=navigator.onLine
-        if (er.status === 0 && (ieVersion === 10 || ieVersion === 11) ) {
+        } else if (zeroStatus && isAffectedIEVersion) {
           er = {};
           er.status = 401;
           er.responseText = {
@@ -1321,20 +1330,14 @@ Auth0.prototype.getDelegationToken = function (options, callback) {
           };
         // If not IE10/11 and not offline it means that Auth0 host is unreachable:
         // Connection Timeout or Connection Refused.
-        } else if ((!er.status || er.status === 0) && window.navigator.onLine) {
+        } else if (zeroStatus) {
           er = {};
           er.status = 0;
           er.responseText = {
-            code: 'connection_refused'
+            code: 'connection_refused_timeout'
           };
-        // Request failed because we are offline.
         } else {
-          er = {};
-          er.status = 0;
-          er.responseText = {
-            code: 'offline'
-          };
-
+          er.responseText = err;
         }
         callback(new LoginError(er.status, er.responseText));
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,31 @@ var use_jsonp         = require('./use_jsonp');
 var LoginError        = require('./LoginError');
 var json_parse        = require('./json-parse');
 
+/**
+ * Check if running in IE.
+ *
+ * @returns {Number} -1 if not IE, IE version otherwise.
+ */
+function isInternetExplorer() {
+  var rv = -1; // Return value assumes failure.
+  var ua = navigator.userAgent;
+  var re;
+  if (navigator.appName === 'Microsoft Internet Explorer') {
+    re = new RegExp('MSIE ([0-9]{1,}[\.0-9]{0,})');
+    if (re.exec(ua) != null) {
+      rv = parseFloat(RegExp.$1);
+    }
+  }
+  // IE > 11
+  else if (ua.indexOf('Trident') > -1) {
+    re = new RegExp('rv:([0-9]{2,2}[\.0-9]{0,})');
+    if (re.exec(ua) !== null) {
+      rv = parseFloat(RegExp.$1);
+    }
+  }
+
+  return rv;
+}
 
 /**
  * Stringify popup options object into
@@ -58,23 +83,33 @@ function checkIfSet(obj, key) {
 
 function handleRequestError(err, callback) {
   var er = err;
+  var ieVersion = isInternetExplorer();
 
   var onLine = !!window.navigator.onLine;
 
   // http://stackoverflow.com/questions/23229723/ie-10-11-cors-status-0
   // XXX IE10 when a request fails in CORS returns status code 0
   // See: http://caniuse.com/#search=navigator.onLine
-  if ((!er.status || er.status === 0) && !onLine ) {
+  if (er.status === 0 && (ieVersion === 10 || ieVersion === 11) ) {
+    er = {};
+    er.status = 401;
+    er.responseText = {
+      code: 'invalid_user_password'
+    };
+  // Request failed because we are offline.
+  } else if ((!er.status || er.status === 0) && !onLine ) {
     er = {};
     er.status = 0;
     er.responseText = {
       code: 'offline'
     };
+  // If not IE10/11 and not offline it means that Auth0 host is unreachable:
+  // Connection Timeout or Connection Refused.
   } else if (er.status === 0) {
     er = {};
-    er.status = 401;
+    er.status = 0;
     er.responseText = {
-      code: 'invalid_user_password'
+      code: 'connection_refused'
     };
   } else {
     er.responseText = err;
@@ -1272,16 +1307,27 @@ Auth0.prototype.getDelegationToken = function (options, callback) {
       }
       catch (e) {
         var er = err;
+        var ieVersion = isInternetExplorer();
+
         // http://stackoverflow.com/questions/23229723/ie-10-11-cors-status-0
         // XXX IE10 when a request fails in CORS returns status code 0
         // XXX This is not handled by handleRequestError as the errors are different
         // See: http://caniuse.com/#search=navigator.onLine
-        if ((!er.status || er.status === 0) && window.navigator.onLine) {
+        if (er.status === 0 && (ieVersion === 10 || ieVersion === 11) ) {
           er = {};
           er.status = 401;
           er.responseText = {
             code: 'invalid_operation'
           };
+        // If not IE10/11 and not offline it means that Auth0 host is unreachable:
+        // Connection Timeout or Connection Refused.
+        } else if ((!er.status || er.status === 0) && window.navigator.onLine) {
+          er = {};
+          er.status = 0;
+          er.responseText = {
+            code: 'connection_refused'
+          };
+        // Request failed because we are offline.
         } else {
           er = {};
           er.status = 0;


### PR DESCRIPTION
> Fixes #75

Previously, the case where the browser was online and the connection failed was handled on the same manner as when on IE10/11 CORS failed. A new IE version check was added to report the CORS error. When both conditions are true (not IE and a 0 status code) that means that a request to Auth0 failed because of connection refuse or timeout. 
