### PR TITLE
Fix incorrect base64 decode

### DIFF
--- a/lib/base64_url_decode.js
+++ b/lib/base64_url_decode.js
@@ -18,7 +18,7 @@ module.exports = base64_url_decode;
  */
 
 function base64_url_decode(str) {
-  var output = str.replace("-", "+").replace("_", "/");
+  var output = str.replace(/-/g, "+").replace(/_/g, "/");
 
   switch (output.length % 4) {
     case 0:


### PR DESCRIPTION
Fixes strings containing two or more dashes and/or underscores.

This affected some users, seemingly at random, especially with large tokens!
