### PR TITLE
Updates for crossDomain security policies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ function Auth0 (options) {
   assert_required(options, 'clientID');
   assert_required(options, 'domain');
 
-  this._useJSONP = options.forceJSONP || use_jsonp();
+  this._useJSONP = null != options.forceJSONP ? !!options.forceJSONP : use_jsonp();
   this._clientID = options.clientID;
   this._callbackURL = options.callbackURL || document.location.href;
   this._domain = options.domain;

--- a/lib/same-origin.js
+++ b/lib/same-origin.js
@@ -1,0 +1,14 @@
+/**
+ * Check for same origin policy
+ */
+
+var protocol = window.location.protocol;
+var domain = window.location.hostname;
+var port = window.location.port;
+
+module.exports = same_origin;
+
+function same_origin (tprotocol, tdomain, tport) {
+  tport = tport || '';
+  return protocol === tprotocol && domain === tdomain && port === tport;
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -128,6 +128,25 @@ describe('Auth0', function () {
 
       expect(initialized_without_new).to.be.an(Auth0);
     });
+
+    it('should set forceJSONP to the provided Boolean value', function(done) {
+      var auth0 = new Auth0({
+        clientID:    'aaaabcdefgh',
+        callbackURL: 'https://myapp.com/callback',
+        domain:      'aaa.auth0.com',
+        forceJSONP:  false
+      });
+      expect(auth0._useJSONP).to.be(false);
+
+      auth0 = new Auth0({
+        clientID:    'aaaabcdefgh',
+        callbackURL: 'https://myapp.com/callback',
+        domain:      'aaa.auth0.com',
+        forceJSONP:  true
+      });
+      expect(auth0._useJSONP).to.be(true);
+      done();
+    });
   });
 
   describe('In redirect mode', function () {


### PR DESCRIPTION
- [x] Allow to override the useJSONP policy by disabling with `{forceJSONP: false}` in constructor options
- [x] Only use crossOrigin flags when the origin differs as on the same domain security policies detail