### PR TITLE
Return empty object on parseHash error instead of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -389,7 +389,7 @@ Auth0.prototype.parseHash = function (hash) {
   }
   if(!hash.match(/access_token/)) {
     // Invalid hash URL
-    return null;
+    return {};
   }
   hash = hash.substr(1).replace(/^\//, '');
   parsed_qs = qs.parse(hash);

--- a/test/tests.js
+++ b/test/tests.js
@@ -351,7 +351,7 @@ describe('Auth0', function () {
     });
 
 
-    it('should return null if the hash URL doesn\'t contain access_token/error', function () {
+    it('should return empty object if the hash URL doesn\'t contain access_token/error', function () {
       var hash = '#myfooobarrr=123';
 
       var auth0 = new Auth0({
@@ -360,7 +360,7 @@ describe('Auth0', function () {
         domain:       'aaa.auth0.com'
       });
 
-      expect(auth0.parseHash(hash)).to.eql(null);
+      expect(auth0.parseHash(hash)).to.eql({});
 
     });
 


### PR DESCRIPTION
This facilitates checking for errors when calling parseHash.

Before:
```js
var hash = auth0.parseHash();
// if hash is null, hash.error throws an error
if (hash && hash.error) { ... }
else if (hash) { ... }

// or

var hash = auth0.parseHash();
if (hash) {
  if (hash.error) { ... }
  else { ... }
}
```

After:
```js
var hash = auth0.parseHash();
// {}.error returns undefined, no need to check hash twice
if (hash.error) { ... }
else if (hash) { ... }
```

Thoughts?