### PR TITLE
Add .startPasswordless()

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Passwordless authentication allows users to login without credentials, by using 
 
 #### With Email
 
-Once you have configured a passwordless `email` connection, you can request a link to be sent via email that will allow to login automatically in to the application.
+Once you have configured a passwordless `email` connection, you can request a link to be sent via email that will allow the receiver to sign in to your application.
 
 ```js
 $('.request-email-link').click(function (ev) {

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $('.login-dbconn').click(function () {
 
 ### Passwordless authentication
 
-Passwordless authentication allows users to login without credentials, by using an email or a SMS message, which can be delivered through `startPasswordless()`.
+Passwordless authentication allows users to log in by receiving a one-time password via email or text message.
 
 #### With Email
 

--- a/README.md
+++ b/README.md
@@ -147,27 +147,44 @@ $('.login-dbconn').click(function () {
   });
 ```
 
-### Passwordless authentication with SMS
+### Passwordless authentication
+
+#### With Email
+
+Once you have configured a passwordless `email` connection, you can request a link to be sent via email that will allow to login automatically in to the application.
+
+```js
+$('.request-email-link').click(function (ev) {
+  ev.preventDefault();
+
+  auth0.startPasswordless({ email: $('.email-input').val() }, function (err) {
+    if (err) {
+      alert(err.error_description);
+      return;
+    }
+    // the request was successful and you should receive
+    // an email with the link at the specified address
+  });
+});
+```
+
+#### With SMS
 
 First you must activate and configure your passwordless [Twilio](https://twilio.com) connection in our [dashboard](https://manage.auth0.com/#/connections/passwordless).
 
-After that you can request a passcode to be sent via SMS to a phone number. For that you use the `.requestSMSCode()` with an `apiToken` and a [full-length](https://www.twilio.com/help/faq/phone-numbers/how-do-i-format-phone-numbers-to-work-internationally) `phoneNumber`.
-
-To generate an `apiToken` go [here](https://auth0.com/docs/apiv2). Notice that the generated token must have the `users:create` scope, otherwise it won't work.
-
+After that you can request a passcode to be sent via SMS to a phone number. Ensure the phone number has the proper [full-length format](https://www.twilio.com/help/faq/phone-numbers/how-do-i-format-phone-numbers-to-work-internationally) `phoneNumber`.
 
 ```js
-// request a passcode sent via sms to `phoneNumber`
+// request a passcode sent via sms to `phone_number`
 // using Twilio's configured connection
 $('.request-sms-code').click(function (ev) {
   ev.preventDefault();
 
-  auth0.requestSMSCode({
-    apiToken: 'your-api-token-here',
-    phone: $('.phone-input').val()
+  auth0.startPasswordless({
+    phone_number: $('.phone-input').val()
   }, function (err) {
     if (err) {
-      alert("something went wrong: " + err.message);
+      alert(err.error_description);
       return;
     }
     // the request was successful and you should

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ $('.login-dbconn').click(function () {
 
 ### Passwordless authentication
 
+Passwordless authentication allows users to login without credentials, by using an email or a SMS message, which can be delivered through `startPasswordless()`.
+
 #### With Email
 
 Once you have configured a passwordless `email` connection, you can request a link to be sent via email that will allow to login automatically in to the application.

--- a/README.md
+++ b/README.md
@@ -175,13 +175,13 @@ First you must activate and configure your passwordless [Twilio](https://twilio.
 After that you can request a passcode to be sent via SMS to a phone number. Ensure the phone number has the proper [full-length format](https://www.twilio.com/help/faq/phone-numbers/how-do-i-format-phone-numbers-to-work-internationally) `phoneNumber`.
 
 ```js
-// request a passcode sent via sms to `phone_number`
+// request a passcode sent via sms to `phoneNumber`
 // using Twilio's configured connection
 $('.request-sms-code').click(function (ev) {
   ev.preventDefault();
 
   auth0.startPasswordless({
-    phone_number: $('.phone-input').val()
+    phoneNumber: $('.phone-input').val()
   }, function (err) {
     if (err) {
       alert(err.error_description);

--- a/example/index.html
+++ b/example/index.html
@@ -29,6 +29,11 @@
     <input type="button" class="validate-db" value="validate" />
 
     <hr>
+    <h2>Passwordless authentication with Email</h2>
+    <input class="email-input" value="" placeholder="email" />
+    <input type="button" class="request-email-link" value="request code" />
+
+    <hr>
     <h2>Passwordless authentication with SMS</h2>
     <input class="phone-input" value="" placeholder="phone number" />
     <input type="button" class="request-sms-code" value="request code" />
@@ -146,11 +151,18 @@
             });
         });
 
+        $('.request-email-link').click(function (e) {
+            e.preventDefault();
+            auth0.startPasswordless({ email: $('.email-input').val() }, function (err, result) {
+                if (err) return alert("something went wrong: " + err.message);
+                console.log(result);
+            });
+        });
+
         $('.request-sms-code').click(function (e) {
             e.preventDefault();
-            auth0.requestSMSCode({
-                apiToken: 'your-api-token-here',
-                phoneNumber: $('.phone-input').val()
+            auth0.startPasswordless({
+                phone_number: $('.phone-input').val()
             }, function (err, result) {
                 if (err) return alert("something went wrong: " + err.message);
                 console.log(result);

--- a/example/index.html
+++ b/example/index.html
@@ -162,7 +162,7 @@
         $('.request-sms-code').click(function (e) {
             e.preventDefault();
             auth0.startPasswordless({
-                phone_number: $('.phone-input').val()
+                phoneNumber: $('.phone-input').val()
             }, function (err, result) {
                 if (err) return alert("something went wrong: " + err.message);
                 console.log(result);

--- a/index.js
+++ b/index.js
@@ -1646,7 +1646,7 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
  *
  * @example
  *
- *     auth0.requestPasswordlessCode({email: 'foo@bar.com'}, function (err, result) {
+ *     auth0.startPasswordless({email: 'foo@bar.com'}, function (err, result) {
  *       if (err) return console.log(err.message);
  *       console.log(result);
  *     });

--- a/index.js
+++ b/index.js
@@ -1641,7 +1641,7 @@ Auth0.prototype.startPasswordless = function (options, callback) {
     throw new Error('A callback function is required');
   }
   if (!options.email && !options.phoneNumber) {
-    throw new Error('An email or a phone number is required.');
+    throw new Error('An `email` or a `phoneNumber` is required.');
   }
 
   var protocol = 'https:';

--- a/index.js
+++ b/index.js
@@ -1617,14 +1617,14 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
  * @example
  *     // To send an email
  *     auth0.startPasswordless({email: 'foo@bar.com'}, function (err, result) {
- *       if (err) return console.log(err.message);
+ *       if (err) return console.log(err.error_description);
  *       console.log(result);
  *     });
  *
  * @example
  *     // To send a SMS
  *     auth0.startPasswordless({phone_number: '+14251112222'}, function (err, result) {
- *       if (err) return console.log(err.message);
+ *       if (err) return console.log(err.error_description);
  *       console.log(result);
  *     });
  *

--- a/index.js
+++ b/index.js
@@ -1642,6 +1642,66 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
 };
 
 /**
+ * Send Email to do passwordless authentication
+ *
+ * @example
+ *
+ *     auth0.requestPasswordlessCode({email: 'foo@bar.com'}, function (err, result) {
+ *       if (err) return console.log(err.message);
+ *       console.log(result);
+ *     });
+ *
+ * @method startPasswordless
+ * @param {Object} options
+ * @param {Function} callback
+ */
+
+Auth0.prototype.startPasswordless = function (options, callback) {
+  if ('object' !== typeof options) {
+    throw new Error('An options object is required');
+  }
+  if ('function' !== typeof callback) {
+    throw new Error('A callback function is required');
+  }
+
+  assert_required(options, 'email');
+
+  var protocol = 'https:';
+  var domain = this._domain;
+  var endpoint = '/passwordless/start';
+  var url = joinUrl(protocol, domain, endpoint);
+
+  return reqwest({
+    url:          same_origin(protocol, domain) ? endpoint : url,
+    method:       'post',
+    type:         'json',
+    crossOrigin:  !same_origin(protocol, domain),
+    data:         {
+      client_id: this._clientID,
+      connection: 'email',
+      email: options.email,
+      authParams: {
+         scope: 'openid profile'
+       }
+    }
+  })
+  .fail(function (err) {
+    try {
+      callback(JSON.parse(err.responseText));
+    } catch (e) {
+      var error = new Error(err.status + '(' + err.statusText + '): ' + err.responseText);
+      error.statusCode = err.status;
+      error.error = err.statusText;
+      error.message = err.responseText;
+      callback(error);
+    }
+  })
+  .then(function (result) {
+    callback(null, result);
+  });
+};
+
+/**
  * Expose `Auth0` constructor
  */
 

--- a/index.js
+++ b/index.js
@@ -1664,6 +1664,15 @@ Auth0.prototype.startPasswordless = function (options, callback) {
     data.connection = 'sms';
   }
 
+  if (this._useJSONP) {
+    return jsonp(url + '?' + qs.stringify(data), jsonpOpts, function (err, resp) {
+      if (err) {
+        return callback(new Error(0 + ': ' + err.toString()));
+      }
+      return resp.status === 200 ? callback(null, true) : callback(resp.error);
+    });
+  }
+
   return reqwest({
     url:          same_origin(protocol, domain) ? endpoint : url,
     method:       'post',

--- a/index.js
+++ b/index.js
@@ -1593,6 +1593,10 @@ Auth0.prototype.getConnections = function (callback) {
  */
 
 Auth0.prototype.requestSMSCode = function (options, callback) {
+  if (console && 'function' === typeof console.warn) {
+    console.warn("`requestSMSCode` is deprected, please use `startPasswordless` instead");
+  }
+
   if ('object' !== typeof options) {
     throw new Error('An options object is required');
   }
@@ -1600,45 +1604,11 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
     throw new Error('A callback function is required');
   }
 
-  assert_required(options, 'apiToken');
   assert_required(options, 'phone');
+  options.phone_number = options.phone;
+  delete options.phone;
 
-  var apiToken = options.apiToken;
-  var phone = options.phone;
-
-  var protocol = 'https:';
-  var domain = this._domain;
-  var endpoint = '/api/v2/users';
-  var url = joinUrl(protocol, domain, endpoint);
-
-  return reqwest({
-    url:          same_origin(protocol, domain) ? endpoint : url,
-    method:       'post',
-    type:         'json',
-    crossOrigin:  !same_origin(protocol, domain),
-    headers:      {
-      Authorization: 'Bearer ' + apiToken
-    },
-    data:         {
-      phone_number:   phone,
-      connection:     'sms',
-      email_verified: false
-    }
-  })
-  .fail(function (err) {
-    try {
-      callback(JSON.parse(err.responseText));
-    } catch (e) {
-      var error = new Error(err.status + '(' + err.statusText + '): ' + err.responseText);
-      error.statusCode = err.status;
-      error.error = err.statusText;
-      error.message = err.responseText;
-      callback(error);
-    }
-  })
-  .then(function (result) {
-    callback(null, result);
-  });
+  return this.startPasswordless(options, callback);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1612,11 +1612,18 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
 };
 
 /**
- * Send Email to do passwordless authentication
+ * Send email or SMS to do passwordless authentication
  *
  * @example
- *
+ *     // To send an email
  *     auth0.startPasswordless({email: 'foo@bar.com'}, function (err, result) {
+ *       if (err) return console.log(err.message);
+ *       console.log(result);
+ *     });
+ *
+ * @example
+ *     // To send a SMS
+ *     auth0.startPasswordless({phone_number: '+14251112222'}, function (err, result) {
  *       if (err) return console.log(err.message);
  *       console.log(result);
  *     });

--- a/index.js
+++ b/index.js
@@ -1605,7 +1605,7 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
   }
 
   assert_required(options, 'phone');
-  options.phone_number = options.phone;
+  options.phoneNumber = options.phone;
   delete options.phone;
 
   return this.startPasswordless(options, callback);
@@ -1623,7 +1623,7 @@ Auth0.prototype.requestSMSCode = function (options, callback) {
  *
  * @example
  *     // To send a SMS
- *     auth0.startPasswordless({phone_number: '+14251112222'}, function (err, result) {
+ *     auth0.startPasswordless({phoneNumber: '+14251112222'}, function (err, result) {
  *       if (err) return console.log(err.error_description);
  *       console.log(result);
  *     });
@@ -1640,7 +1640,7 @@ Auth0.prototype.startPasswordless = function (options, callback) {
   if ('function' !== typeof callback) {
     throw new Error('A callback function is required');
   }
-  if (!options.email && !options.phone_number) {
+  if (!options.email && !options.phoneNumber) {
     throw new Error('An email or a phone number is required.');
   }
 
@@ -1660,7 +1660,7 @@ Auth0.prototype.startPasswordless = function (options, callback) {
       data.send = options.send;
     }
   } else {
-    data.phone_number = options.phone_number;
+    data.phone_number = options.phoneNumber;
     data.connection = 'sms';
   }
 

--- a/test/passwordless.tests.js
+++ b/test/passwordless.tests.js
@@ -1,0 +1,92 @@
+/**
+ * Config mocha
+ */
+
+mocha.timeout(60000);
+mocha.globals(['jQuery*', '__auth0jp*']);
+
+/**
+ * Test User and Password
+ */
+
+describe('Auth0 - Passwordless', function () {
+  afterEach(function () {
+    this.server.restore();
+  });
+
+  beforeEach(function () {
+    this.domain = 'aaa.auth0.com';
+    this.clientID = 'aaaabcdefgh';
+    this.auth0 = new Auth0({
+      domain: this.domain,
+      clientID: this.clientID,
+    });
+    this.server = sinon.fakeServer.create();
+    this.email = 'foo@bar.com'
+  });
+
+  describe('.startPasswordless()', function () {
+    it('should throw if no arguments are passed', function () {
+      var auth0 = this.auth0;
+      expect(function () {
+        auth0.startPasswordless();
+      }).to.throwError('An options object is required');
+    });
+
+    it('should throw if no options are passed', function () {
+      var auth0 = this.auth0;
+      expect(function () {
+        auth0.startPasswordless(undefined, function() {});
+      }).to.throwError('An options object is required');
+    });
+
+    it('should throw if no callback is passed', function () {
+      var auth0 = this.auth0;
+      var email = this.email;
+      expect(function () {
+        auth0.startPasswordless({ email: email });
+      }).to.throwError('A callback function is required');
+    });
+
+    it('should throw if options has no property email', function () {
+      var auth0 = this.auth0;
+      expect(function () {
+        auth0.startPasswordless({}, function() {});
+      }).to.throwError('email is required.');
+    });
+
+    it('should send email successfully', function (done) {
+      this.server.respondWith('POST', 'https://' + this.domain + '/passwordless/start', [
+        200,
+        { 'Content-Type': 'application/json' },
+        '{"_id":"5b7bb4","email":"foo@bar.com"}'
+      ]);
+
+      this.auth0.startPasswordless({ email: this.email }, function (err) {
+        expect(err).to.be(null);
+        done();
+      });
+
+      this.server.respond();
+    });
+    //
+    it('should fail using invalid email', function (done) {
+      this.server.respondWith('POST', 'https://' + this.domain + '/passwordless/start', [
+        400,
+        { 'Content-Type': 'application/json' },
+        '{"error":"bad.email","error_description":"error in email - email format validation failed: foo"}'
+      ]);
+
+      this.auth0.startPasswordless({ email: this.email }, function (err) {
+        expect(err).not.to.be(null);
+        expect(err).to.have.property('error');
+        expect(err).to.have.property('error_description');
+        expect(err.error).to.be('bad.email');
+        expect(err.error_description).to.be('error in email - email format validation failed: foo');
+        done();
+      });
+
+      this.server.respond();
+    });
+  });
+});

--- a/test/passwordless.tests.js
+++ b/test/passwordless.tests.js
@@ -23,7 +23,7 @@ describe('Auth0 - Passwordless', function () {
     });
     this.server = sinon.fakeServer.create();
     this.email = 'foo@bar.com';
-    this.phone_number = '+5491122334455';
+    this.phoneNumber = '+5491122334455';
   });
 
   describe('.startPasswordless()', function () {
@@ -49,7 +49,7 @@ describe('Auth0 - Passwordless', function () {
       }).to.throwError('A callback function is required');
     });
 
-    it('should throw if options has no property email or phone_number', function () {
+    it('should throw if options has no property email or phoneNumber', function () {
       var auth0 = this.auth0;
       expect(function () {
         auth0.startPasswordless({}, function() {});
@@ -142,20 +142,20 @@ describe('Auth0 - Passwordless', function () {
       });
 
       it('should send the expected parameters', function (done) {
-        this.auth0.startPasswordless({ phone_number: this.phone_number }, function (err) {
+        this.auth0.startPasswordless({ phoneNumber: this.phoneNumber }, function (err) {
           expect(err).to.be(null);
           done();
         });
 
         var requestData = parseRequestBody(this.server.requests[0]);
         expect(requestData.client_id).to.be(this.clientID);
-        expect(requestData.phone_number).to.be(this.phone_number);
+        expect(requestData.phone_number).to.be(this.phoneNumber);
         expect(requestData.connection).to.be('sms');
         this.server.respond();
       });
 
       it('should not allow a send option', function (done) {
-        this.auth0.startPasswordless({ phone_number: this.phone_number, send: 'link' }, function (err) {
+        this.auth0.startPasswordless({ phoneNumber: this.phoneNumber, send: 'link' }, function (err) {
           done();
         });
 
@@ -165,7 +165,7 @@ describe('Auth0 - Passwordless', function () {
       });
 
       it('should not allow an authParams option', function (done) {
-        this.auth0.startPasswordless({ phone_number: this.phone_number, authParams: 'fakeauthparams' }, function (err) {
+        this.auth0.startPasswordless({ phoneNumber: this.phoneNumber, authParams: 'fakeauthparams' }, function (err) {
           done();
         });
 
@@ -178,16 +178,16 @@ describe('Auth0 - Passwordless', function () {
 
     describe('unsuccessful attempt to send a sms', function() {
       beforeEach(function() {
-        this.phone_number = '+541234';
+        this.phoneNumber = '+541234';
         this.server.respondWith('POST', 'https://' + this.domain + '/passwordless/start', [
           400,
           { 'Content-Type': 'application/json' },
-          '{"statusCode":400,"error":"Bad Request","message":"The \'To\' number ' + this.phone_number + ' is not a valid phone number."}'
+          '{"statusCode":400,"error":"Bad Request","message":"The \'To\' number ' + this.phoneNumber + ' is not a valid phone number."}'
         ]);
       });
 
       it('should provide the error information', function (done) {
-        this.auth0.startPasswordless({ phone_number: this.phone_number }, function (err) {
+        this.auth0.startPasswordless({ phoneNumber: this.phoneNumber }, function (err) {
           expect(err).not.to.be(null);
           expect(err).to.have.property('statusCode');
           expect(err).to.have.property('error');
@@ -231,7 +231,7 @@ describe('Auth0 - Passwordless', function () {
       });
 
       it('should send the expected parameters', function (done) {
-        this.auth0.login({ phone: this.phone_number, passcode: this.passcode }, function (err, profile) {
+        this.auth0.login({ phone: this.phoneNumber, passcode: this.passcode }, function (err, profile) {
           expect(err).to.be(null);
           done();
         });
@@ -240,7 +240,7 @@ describe('Auth0 - Passwordless', function () {
         expect(requestData.client_id).to.be(this.clientID);
         expect(requestData.connection).to.be('sms');
         expect(requestData.grant_type).to.be('password');
-        expect(requestData.username).to.be(this.phone_number);
+        expect(requestData.username).to.be(this.phoneNumber);
         expect(requestData.password).to.be(this.passcode);
         expect(requestData.scope).to.be('openid');
         expect(requestData.sso).to.be('false');

--- a/test/sms.tests.js
+++ b/test/sms.tests.js
@@ -50,65 +50,30 @@ describe('Auth0 - SMS', function () {
 
     it('should throw if no callback is passed', function () {
       var auth0 = this.auth0;
-      var apiToken = this.apiToken;
-      var phone = this.phone;
-      expect(function () {
-        auth0.requestSMSCode({ apiToken: apiToken, phone: phone });
-      }).to.throwError('A callback function is required');
-    });
-
-    it('should throw if options has no property apiToken', function () {
-      var auth0 = this.auth0;
-      var apiToken = this.apiToken;
       var phone = this.phone;
       expect(function () {
         auth0.requestSMSCode({ phone: phone });
-      }).to.throwError('apiToken is required.');
+      }).to.throwError('A callback function is required');
     });
 
     it('should throw if options has no property phone', function () {
       var auth0 = this.auth0;
-      var apiToken = this.apiToken;
       var phone = this.phone;
       expect(function () {
-        auth0.requestSMSCode({ apiToken: apiToken });
+        auth0.requestSMSCode({}, function() {});
       }).to.throwError('phone is required.');
     });
 
-    it('should send sms successfully', function (done) {
-      this.server.respondWith('POST', 'https://' + this.domain + '/api/v2/users', [
-        200,
-        { 'Content-Type': 'application/json' },
-        '{}'
-      ]);
-
-      this.auth0.requestSMSCode({ apiToken: this.apiToken, phone: this.phone }, function (err) {
-        expect(err).to.be(null);
+    it('should call startPasswordless', function(done) {
+      var callback = function() {};
+      var phone = this.phone;
+      this.auth0.startPasswordless = function(options, cb) {
+        expect(cb).to.be(callback);
+        expect(options).to.eql({phone_number: phone, other: 'other'});
         done();
-      });
+      };
 
-      this.server.respond();
-    });
-
-    it('should fail using invalid phone number', function (done) {
-      this.server.respondWith('POST', 'https://' + this.domain + '/api/v2/users', [
-        400,
-        { 'Content-Type': 'application/json' },
-        '{"statusCode":400,"error":"Bad Request","message":"The \'To\' number 541234 is not a valid phone number."}'
-      ]);
-
-      this.auth0.requestSMSCode({ apiToken: this.apiToken, phone: '+541234' }, function (err) {
-        expect(err).not.to.be(null);
-        expect(err).to.have.property('statusCode');
-        expect(err).to.have.property('error');
-        expect(err).to.have.property('message');
-        expect(err.statusCode).to.be(400);
-        expect(err.error).to.be('Bad Request');
-        expect(err.message).to.be('The \'To\' number 541234 is not a valid phone number.');
-        done();
-      });
-
-      this.server.respond();
+      this.auth0.requestSMSCode({ phone: this.phone, other: 'other' }, callback);
     });
   });
 

--- a/test/sms.tests.js
+++ b/test/sms.tests.js
@@ -69,7 +69,7 @@ describe('Auth0 - SMS', function () {
       var phone = this.phone;
       this.auth0.startPasswordless = function(options, cb) {
         expect(cb).to.be(callback);
-        expect(options).to.eql({phone_number: phone, other: 'other'});
+        expect(options).to.eql({phoneNumber: phone, other: 'other'});
         done();
       };
 

--- a/test_harness.html
+++ b/test_harness.html
@@ -27,6 +27,7 @@
   <!-- tests -->
   <script src="/test/tests.js"></script>
   <script src="/test/user-and-pass.tests.js"></script>
+  <script src="/test/passwordless.tests.js"></script>
   <script src="/test/sms.tests.js"></script>
   <script src="/test/logout.js"></script>
 


### PR DESCRIPTION
@cristiandouce @woloski what do you think about the method's name? It matches the endpoint's path, which sends an email with a link by default but it can include a code instead.

There's a fair bit of duplication between this method and `requestSMSCode()`, specially in the logic that handles the request.