### PR TITLE
Move build to the beginning in examples tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -158,8 +158,8 @@ module.exports = function(grunt) {
   }
 
   grunt.registerTask("build",         ["clean", "browserify:dist", "uglify:min", "copy:example"]);
-  grunt.registerTask("example",       ["connect:example", "watch", "build"]);
-  grunt.registerTask("example_https", ["connect:example_https", "watch", "build"]);
+  grunt.registerTask("example",       ["build", "connect:example", "watch"]);
+  grunt.registerTask("example_https", ["build", "connect:example_https", "watch"]);
 
   grunt.registerTask("dev",           ["build", "connect:test", "watch"]);
   grunt.registerTask("integration",   ["exec:test-integration"]);


### PR DESCRIPTION
Otherwise _auth0.js_ is not being copied to the _example_ dir.

![screen shot 2015-08-07 at 11 37 51 am](https://cloud.githubusercontent.com/assets/120195/9138398/dbd38c92-3cf9-11e5-9af4-95e9f6c1985a.png)
