### PR TITLE
fix jsonp error response for signup: wrong field name

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,7 +537,7 @@ Auth0.prototype.signup = function (options, callback) {
       }
       return resp.status == 200 ?
               success() :
-              fail(resp.status, resp.err);
+              fail(resp.status, resp.error);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -1673,7 +1673,7 @@ Auth0.prototype.startPasswordless = function (options, callback) {
       if (err) {
         return callback(new Error(0 + ': ' + err.toString()));
       }
-      return resp.status === 200 ? callback(null, true) : callback(resp.error);
+      return resp.status === 200 ? callback(null, true) : callback(resp.error || resp.err);
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -1673,7 +1673,7 @@ Auth0.prototype.startPasswordless = function (options, callback) {
       if (err) {
         return callback(new Error(0 + ': ' + err.toString()));
       }
-      return resp.status === 200 ? callback(null, true) : callback(resp.error || resp.err);
+      return resp.status === 200 ? callback(null, true) : callback(resp.err || resp.error);
     });
   }
 


### PR DESCRIPTION
Auth0.js is expecting to receive a `.err` attribute for JSONP signup responses but it is returning it as `error`

```
/**/ typeof __auth0jp0 === 'function' && __auth0jp0({"error":{"name":"BadRequestError","code":"user_exists","description":"The user already exists.","statusCode":400},"status":400});
```