### PR TITLE
Fix handling of errors from mozzila/winchan to properly handle rules custom errors

### DIFF
--- a/bin/version
+++ b/bin/version
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 var path = require('path');
-var bump = require('bump');
+var bump = require('bump-version');
 var unreleased = require('unreleased');
 var fs = require('fs');
 

--- a/index.js
+++ b/index.js
@@ -916,19 +916,36 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
     relay_url: 'https://' + this._domain + '/relay.html',
     window_features: stringifyPopupSettings(popupOptions)
   }, function (err, result) {
+    // Winchan always returns string errors, we wrap them inside Error objects
     if (err) {
-      // Winchan always returns string errors, we wrap them inside Error objects
-      return callback(new Error(err), null, null, null, null, null);
+      return callback(new LoginError(err), null, null, null, null, null);
     }
 
-    if (result && result.id_token) {
+    // Handle edge case with generic error
+    if (!result) {
+      return callback(new LoginError('Something went wrong'), null, null, null, null, null);
+    }
+
+    // Handle profile retrieval from id_token and respond
+    if (result.id_token) {
       return self.getProfile(result.id_token, function (err, profile) {
         callback(err, profile, result.id_token, result.access_token, result.state, result.refresh_token);
       });
     }
 
-    // Case where we've found an error
-    return callback(new Error(result ? result.err : 'Something went wrong'), null, null, null, null, null);
+    // Case where the error is returned at an `err` property from the result
+    if (result.err) {
+      return callback(new LoginError(result.err.status, result.err.details || result.err), null, null, null, null, null);
+    }
+
+    // Case for sso_dbconnection_popup returning error at result.error instead of result.err
+    if (result.error) {
+      if (null == result.status && 'unauthorized' === result.error) result.status = 401;
+      return callback(new LoginError(result.status, result.details || result), null, null, null, null, null);
+    }
+
+    // Case we couldn't match any error, we return a generic one
+    return callback(new LoginError('Something went wrong'), null, null, null, null, null);
   });
 
   popup.focus();

--- a/index.js
+++ b/index.js
@@ -940,7 +940,6 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
 
     // Case for sso_dbconnection_popup returning error at result.error instead of result.err
     if (result.error) {
-      if (null == result.status && 'unauthorized' === result.error) result.status = 401;
       return callback(new LoginError(result.status, result.details || result), null, null, null, null, null);
     }
 
@@ -1077,7 +1076,6 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
 
     // Case for sso_dbconnection_popup returning error at result.error instead of result.err
     if (result.error) {
-      if (null == result.status && 'unauthorized' === result.error) result.status = 401;
       return callback(new LoginError(result.status, result.details || result), null, null, null, null, null);
     }
 

--- a/lib/LoginError.js
+++ b/lib/LoginError.js
@@ -31,8 +31,12 @@ function LoginError(status, details) {
     obj = details || { description: 'server error' };
   }
 
-  if (obj && !obj.code) {
+  if (!obj.code) {
     obj.code = obj.error;
+  }
+
+  if ('unauthorized' === obj.code) {
+    status = 401;
   }
 
   var err = Error.call(this, obj.description || obj.message || obj.error);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "browserify": "~2.35.0",
     "browserstack-cli": "0.3.1",
-    "bump": "git://github.com/ianstormtaylor/bump",
+    "bump-version": "^0.5.0",
     "expect.js": "~0.2.0",
     "grunt": "~0.4.5",
     "grunt-aws-s3": "~0.9.3",


### PR DESCRIPTION
For `.loginWithPopup()` the error was not being wrapped inside a `LoginError` causing unexpected nor predictable results when being handled from Lock or other sources.

Also, for cases with non-xhr I forced the 401 status code for `unauthorized` error code.