### PR TITLE
Properly set response_type in requestMagicLink

### DIFF
--- a/index.js
+++ b/index.js
@@ -1737,13 +1737,14 @@ Auth0.prototype.startPasswordless = function (options, callback) {
       data.authParams = options.authParams;
     }
 
-    if (this._shouldRedirect && !options.send || options.send === "link") {
+    if (!options.send || options.send === "link") {
       if (!data.authParams) {
         data.authParams = {};
       }
 
       data.authParams.redirect_uri = this._callbackURL;
-      data.authParams.response_type = this._callbackOnLocationHash ? "token" : "code";
+      data.authParams.response_type = this._shouldRedirect && !this._callbackOnLocationHash ?
+        "code" : "token";
     }
 
     if (options.send) {


### PR DESCRIPTION
Set `response_type` to `token` when calling `requestMagicLink` if a `callbackURL` wasn't provided to the constructor. 