### PR TITLE
Alter Auth0.prototype.logout method to use v2 endpoint.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1621,7 +1621,7 @@ Auth0.prototype.getDelegationToken = function (options, callback) {
  */
 
 Auth0.prototype.logout = function (query) {
-  var url = joinUrl('https:', this._domain, '/logout');
+  var url = joinUrl('https:', this._domain, '/v2/logout');
   if (query) {
     url += '?' + qs.stringify(query);
   }


### PR DESCRIPTION
As mentioned in https://github.com/auth0/auth0.js/issues/74, it would be nice if the `.logout()` method pointed to the endpoint noted in the documentation at https://auth0.com/docs/logout.

Review and comments are welcome. =)