### PR TITLE
Add support for scopes from options parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,16 @@ Auth0.prototype._renderAndSubmitWSFedForm = function (options, formHtml) {
  */
 
 Auth0.prototype._getMode = function (options) {
+
+  var scope;
+  if (typeof(options.scope) != "undefined") {
+    scope = { scope: 'openid' };
+  }else {
+    scope = options.scope
+  }
+
   return {
-    scope: 'openid',
+    scope: scope,
     response_type: this._getCallbackOnLocationHash(options) ? 'token' : 'code'
   };
 };
@@ -1170,8 +1178,15 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
 
 Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
   var _this = this;
+  var scope;
+  if (typeof(options.scope) != "undefined") {
+    scope = { scope: 'openid' };
+  }else {
+    scope = options.scope
+  }
+
   var query = this._buildAuthorizationParameters([
-      { scope: 'openid' },
+      scope,
       options,
       { client_id: this._clientID }
     ]);


### PR DESCRIPTION
This pull request contains modifications to allow Auth0 Lock to specify multiple scopes for JWT and avoid  to have a fixed scope in the JWT return.