### PR TITLE
No auto profile fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are using [browserify](http://browserify.org/) install with `npm i auth0-
 
 > Note: The following examples use jQuery, but auth0.js is not tied to jQuery and any library can be used with it.
 
-### Initialize:
+### Initialize
 
 Construct a new instance of the Auth0 client as follows:
 
@@ -42,7 +42,7 @@ Construct a new instance of the Auth0 client as follows:
 </script>
 ```
 
-### Login:
+### Login
 
 This method can be called as indifferently as `signin` or `login`.
 Triggers the login on any of your active identity provider as follows:
@@ -78,14 +78,14 @@ Triggers the login on any of your active identity provider as follows:
     });
   });
 
-  //trigger login with a db connection and avoid the redirect (best experience for SPA)
+  //trigger login with a db connection and avoid the redirect
   $('.login-dbconn').click(function () {
     auth0.login({
       connection: 'db-conn',
       username:   $('.username').val(),
       password:   $('.password').val(),
     },
-    function (err, profile, id_token, access_token) {
+    function (err, result) {
       // store in cookies
     });
   });
@@ -100,12 +100,12 @@ Triggers the login on any of your active identity provider as follows:
         width: 450,
         height: 800
       }
-    }, function(err, profile, id_token, access_token, state) {
+    }, function(err, result) {
       if (err) {
         alert("something went wrong: " + err.message);
         return;
       }
-      alert('hello ' + profile.name);
+      alert('Hello!');
     });
   });
 ```
@@ -140,9 +140,9 @@ $('.login-dbconn').click(function () {
       password:   $('.password').val(),
       scope: 'openid offline_access'
     },
-    function (err, profile, id_token, access_token, state, refresh_token) {
+    function (err, result) {
       // store in cookies
-      // refresh_token is sent because offline_access is set as a scope
+      // result.refreshToken is sent because offline_access is set as a scope
     });
   });
 ```
@@ -194,25 +194,25 @@ $('.request-email-code').click(function (ev) {
 });
 ```
 
-Once you receive the code you can call `verifyEmailCode` to authenticate the user using an `email` and a `code` and obtain the user's information such as its profile.
+Once you receive the code you can call `verifyEmailCode` to authenticate the user using an `email` and a `code`.
 
 ```js
 auth0.verifyEmailCode({
   email: $('.email-input').val(),
   code: $('.email-code-input').val()
-}, function (err, profile, id_token, access_token, state, refresh_token) {
+}, function (err, result) {
   if (err) {
     alert("something went wrong: " + err.error_description);
     return;
   }
-  console.log(profile, id_token, access_token, state, refresh_token);
+  alert('Hello');
 });
 ```
 
 If you provide a `callbackURL` parameter when constructing the Auth0 instance, a redirect will be performed and the callback will only be invoked in the case of an error (notice it takes a single argument).
 
 ```js
-auth0.verifyEmailCode(auth0.verifyEmailCode({
+auth0.verifyEmailCode({
   email: $('.email-input').val(),
   code: $('.email-code-input').val()
 }, function (err) {
@@ -247,18 +247,18 @@ $('.request-sms-code').click(function (ev) {
 });
 ```
 
-Once you receive the code you can call `verifySMSCode` to authenticate the user using an `phoneNumber` and a `code` and obtain the user's information such as its profile.
+Once you receive the code you can call `verifySMSCode` to authenticate the user using an `phoneNumber` and a `code`.
 
 ```js
 auth0.verifySMSCode({
   phoneNumber: $('.phone-input').val(),
   code: $('.sms-code-input').val()
-}, function (err, profile, id_token, access_token, state, refresh_token) {
+}, function (err, result) {
   if (err) {
     alert("something went wrong: " + err.error_description);
     return;
   }
-  console.log(profile, id_token, access_token, state, refresh_token);
+  alert("Hello");
 });
 ```
 
@@ -275,6 +275,23 @@ auth0.verifySMSCode({
   }
 });
 ```
+
+### User Profile
+
+The `getProfile` method allows you to obtain the user information after a successful login, and validates the JSON Web Token.
+
+```js
+auth0.getProfile(idToken, function (err, profile) {
+  if(err) {
+    // handle error
+    return;
+  }
+
+  alert('hello ' + profile.name);
+});
+```
+
+How do you get hold of the `idToken` depends on the mode you are using to log in. See below for examples for [redirect](#single-page-apps) and [popup](#popup-mode) modes.
 
 ### Processing the Callback
 
@@ -300,12 +317,14 @@ If you're building a SPA (Single Page Application) and using Redirect Mode, then
 $(function () {
   var result = auth0.parseHash(window.location.hash);
 
-  //use result.id_token to call your rest api
+  //use result.idToken to call your rest api
 
-  if (result && result.id_token) {
-    auth0.getProfile(result.id_token, function (err, profile) {
+  if (result && result.idToken) {
+    // optionally fetch user profile
+    auth0.getProfile(result.idToken, function (err, profile) {
       alert('hello ' + profile.name);
     });
+
     // If offline_access was a requested scope
     // You can grab the result.refresh_token here
 
@@ -360,13 +379,18 @@ auth0.login({
   popup: true,
   connection: 'google-oauth2'
 },
-function(err, profile, id_token, access_token, state) {
+function(err, result) {
   if (err) {
     // Handle the error!
     return;
   }
 
   // Success!
+
+  // optionally fetch user profile
+  auth0.getProfile(result.idToken, function (err, profile) {
+    alert('hello ' + profile.name);
+  });
 });
 ```
 
@@ -401,7 +425,7 @@ auth0.login({
   username:   $('.username').val(),
   password:   $('.password').val(),
 },
-function(err, profile, id_token, access_token, state) {
+function(err, result) {
   if (err) {
     // Handle the error!
     return;
@@ -420,7 +444,7 @@ auth0.login({
   connection: 'db-conn',
   popup: true
 },
-function(err, profile, id_token, access_token, state) {
+function(err, result) {
   if (err) {
     // Handle the error!
     return;
@@ -446,14 +470,14 @@ auth0.login({
   connection: 'db-conn',
   sso: false,
   username:   $('.username').val(),
-  password:   $('.password').val()  
+  password:   $('.password').val()
 },
 function(err) {
   // this only gets called if there was a login error
 });
 ```
 
-If the login succeeds, Auth0 will redirect to your `callbackURL` and if it fails, control will be given to the `callback`.  
+If the login succeeds, Auth0 will redirect to your `callbackURL` and if it fails, control will be given to the `callback`.
 
 And if you don't want that redirect to occur (i.e. you have a Single Page App), you can use a `callback` argument that takes the additional parameters (like what's shown in [Popup Mode](#popup-mode)), and control will go to your callback function with a failed or successful login.
 
@@ -483,11 +507,11 @@ If you just want to get a new token for an addon that you've activated, you can 
 var options = {
   id_token: "your id token", // The id_token you have now
   api: 'firebase', // This defaults to the first active addon if any or you can specify this
-  "scope": "openid profile"		    // default: openid
+  "scope": "openid profile"         // default: openid
 };
 
 auth0.getDelegationToken(options, function (err, delegationResult) {
-	// Call your API using delegationResult.id_token
+    // Call your API using delegationResult.id_token
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -1119,11 +1119,6 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
     query['auth0Client'] = this._getClientInfoString();
   }
 
-  function enrichGetProfile(resp, callback) {
-    // TODO: we don't need enrichGetProfile anymore
-    callback(null, prepareResult(resp));
-  }
-
   if (this._useJSONP) {
     return jsonp(url + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
@@ -1133,7 +1128,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
         var error = new LoginError(resp.status, resp.error);
         return callback(error);
       }
-      enrichGetProfile(resp, callback);
+      callback(null, prepareResult(resp));
     });
   }
 
@@ -1145,7 +1140,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
     headers: this._getClientInfoHeader(),
     crossOrigin: !same_origin(protocol, domain),
     success: function (resp) {
-      enrichGetProfile(resp, callback);
+      callback(null, prepareResult(resp));
     },
     error: function (err) {
       handleRequestError(err, callback);
@@ -1174,11 +1169,6 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
   var endpoint = '/oauth/access_token';
   var url = joinUrl(protocol, domain, endpoint);
 
-  function enrichGetProfile(resp, callback) {
-    // TODO: we don't need enrichGetProfile anymore
-    callback(null, prepareResult(resp));
-  }
-
   if (this._useJSONP) {
     return jsonp(url + '?' + qs.stringify(query), jsonpOpts, function (err, resp) {
       if (err) {
@@ -1188,7 +1178,7 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
         var error = new LoginError(resp.status, resp.error);
         return callback(error);
       }
-      enrichGetProfile(resp, callback);
+      callback(null, prepareResult(resp));
     });
   }
 
@@ -1200,7 +1190,7 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
     headers: this._getClientInfoHeader(),
     crossOrigin: !same_origin(protocol, domain),
     success: function (resp) {
-      enrichGetProfile(resp, callback);
+      callback(null, prepareResult(resp));
     },
     error: function (err) {
       handleRequestError(err, callback);

--- a/index.js
+++ b/index.js
@@ -837,9 +837,7 @@ Auth0.prototype.loginPhonegap = function (options, callback) {
     }
 
     if (result.id_token) {
-      _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, prepareResult(result));
-      });
+      setTimeout(function() { callback(null, prepareResult(result)) }, 0);
       answered = true;
       return ref.close();
     }
@@ -937,9 +935,7 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
 
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
-      return _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, prepareResult(result));
-      });
+      return callback(null, prepareResult(result));
     }
 
     // Case where the error is returned at an `err` property from the result
@@ -1073,9 +1069,7 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
 
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
-      return _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, prepareResult(result));
-      });
+      return callback(null, prepareResult(result));
     }
 
     // Case where the error is returned at an `err` property from the result
@@ -1126,9 +1120,8 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
   }
 
   function enrichGetProfile(resp, callback) {
-    _this.getProfile(resp.id_token, function (err, profile) {
-      callback(err, profile, prepareResult(resp));
-    });
+    // TODO: we don't need enrichGetProfile anymore
+    callback(null, prepareResult(resp));
   }
 
   if (this._useJSONP) {
@@ -1182,9 +1175,8 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
   var url = joinUrl(protocol, domain, endpoint);
 
   function enrichGetProfile(resp, callback) {
-    _this.getProfile(resp.id_token, function (err, profile) {
-      callback(err, profile, prepareResult(resp));
-    });
+    // TODO: we don't need enrichGetProfile anymore
+    callback(null, prepareResult(resp));
   }
 
   if (this._useJSONP) {

--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ Auth0.prototype.parseHash = function (hash) {
   return {
     accessToken: parsed_qs.access_token,
     idToken: id_token,
-    profile: prof, // TODO: this is not the profile
+    idTokenData: prof,
     refreshToken: refresh_token,
     state: parsed_qs.state
   };
@@ -1820,7 +1820,7 @@ Auth0.prototype._prepareResult = function(result) {
   return {
     accessToken: result.access_token,
     idToken: result.id_token,
-    profile: idTokenData,
+    idTokenData: idTokenData,
     refreshToken: result.refresh_token,
     state: result.state
   };

--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ Auth0.prototype.parseHash = function (hash) {
   return {
     accessToken: parsed_qs.access_token,
     idToken: id_token,
-    profile: prof, // TODO: this is not the profile and is not provided in popup mode
+    profile: prof, // TODO: this is not the profile
     refreshToken: refresh_token,
     state: parsed_qs.state
   };
@@ -837,7 +837,7 @@ Auth0.prototype.loginPhonegap = function (options, callback) {
     }
 
     if (result.id_token) {
-      setTimeout(function() { callback(null, prepareResult(result)) }, 0);
+      setTimeout(function() { callback(null, _this._prepareResult(result)) }, 0);
       answered = true;
       return ref.close();
     }
@@ -935,7 +935,7 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
 
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
-      return callback(null, prepareResult(result));
+      return callback(null, _this._prepareResult(result));
     }
 
     // Case where the error is returned at an `err` property from the result
@@ -1069,7 +1069,7 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
 
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
-      return callback(null, prepareResult(result));
+      return callback(null, _this._prepareResult(result));
     }
 
     // Case where the error is returned at an `err` property from the result
@@ -1128,7 +1128,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
         var error = new LoginError(resp.status, resp.error);
         return callback(error);
       }
-      callback(null, prepareResult(resp));
+      callback(null, _this._prepareResult(resp));
     });
   }
 
@@ -1140,7 +1140,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
     headers: this._getClientInfoHeader(),
     crossOrigin: !same_origin(protocol, domain),
     success: function (resp) {
-      callback(null, prepareResult(resp));
+      callback(null, _this._prepareResult(resp));
     },
     error: function (err) {
       handleRequestError(err, callback);
@@ -1178,7 +1178,7 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
         var error = new LoginError(resp.status, resp.error);
         return callback(error);
       }
-      callback(null, prepareResult(resp));
+      callback(null, _this._prepareResult(resp));
     });
   }
 
@@ -1190,7 +1190,7 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
     headers: this._getClientInfoHeader(),
     crossOrigin: !same_origin(protocol, domain),
     success: function (resp) {
-      callback(null, prepareResult(resp));
+      callback(null, _this._prepareResult(resp));
     },
     error: function (err) {
       handleRequestError(err, callback);
@@ -1808,15 +1808,22 @@ Auth0.prototype.verifySMSCode = function(attrs, cb) {
   return this.login(attrs, cb);
 };
 
-function prepareResult(result) {
-  return !result || typeof result !== "object"
-    ? undefined
-    : {
-        accessToken: result.access_token,
-        idToken: result.id_token,
-        refreshToken: result.refresh_token,
-        state: result.state
-      };
+Auth0.prototype._prepareResult = function(result) {
+  if (!result || typeof result !== "object") {
+    return;
+  }
+
+  var idTokenData = result.profile
+    ? result.profile
+    : this.decodeJwt(result.id_token);
+
+  return {
+    accessToken: result.access_token,
+    idToken: result.id_token,
+    profile: idTokenData,
+    refreshToken: result.refresh_token,
+    state: result.state
+  };
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -464,7 +464,7 @@ Auth0.prototype.parseHash = function (hash) {
   return {
     accessToken: parsed_qs.access_token,
     idToken: id_token,
-    idTokenData: prof,
+    idTokenPayload: prof,
     refreshToken: refresh_token,
     state: parsed_qs.state
   };
@@ -1813,14 +1813,14 @@ Auth0.prototype._prepareResult = function(result) {
     return;
   }
 
-  var idTokenData = result.profile
+  var idTokenPayload = result.profile
     ? result.profile
     : this.decodeJwt(result.id_token);
 
   return {
     accessToken: result.access_token,
     idToken: result.id_token,
-    idTokenData: idTokenData,
+    idTokenPayload: idTokenPayload,
     refreshToken: result.refresh_token,
     state: result.state
   };

--- a/index.js
+++ b/index.js
@@ -462,11 +462,11 @@ Auth0.prototype.parseHash = function (hash) {
   }
 
   return {
-    profile: prof,
-    id_token: id_token,
-    access_token: parsed_qs.access_token,
-    state: parsed_qs.state,
-    refresh_token: refresh_token
+    accessToken: parsed_qs.access_token,
+    idToken: id_token,
+    profile: prof, // TODO: this is not the profile and is not provided in popup mode
+    refreshToken: refresh_token,
+    state: parsed_qs.state
   };
 };
 
@@ -1829,7 +1829,12 @@ Auth0.prototype.verifySMSCode = function(attrs, cb) {
 function prepareResult(result) {
   return !result || typeof result !== "object"
     ? undefined
-    : result;
+    : {
+        accessToken: result.access_token,
+        idToken: result.id_token,
+        refreshToken: result.refresh_token,
+        state: result.state
+      };
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -838,7 +838,7 @@ Auth0.prototype.loginPhonegap = function (options, callback) {
 
     if (result.id_token) {
       _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, result.id_token, result.access_token, result.state, result.refresh_token);
+        callback(err, profile, prepareResult(result));
       });
       answered = true;
       return ref.close();
@@ -938,7 +938,7 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
       return _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, result.id_token, result.access_token, result.state, result.refresh_token);
+        callback(err, profile, prepareResult(result));
       });
     }
 
@@ -1074,7 +1074,7 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
     // Handle profile retrieval from id_token and respond
     if (result.id_token) {
       return _this.getProfile(result.id_token, function (err, profile) {
-        callback(err, profile, result.id_token, result.access_token, result.state, result.refresh_token);
+        callback(err, profile, prepareResult(result));
       });
     }
 
@@ -1127,7 +1127,7 @@ Auth0.prototype.loginWithResourceOwner = function (options, callback) {
 
   function enrichGetProfile(resp, callback) {
     _this.getProfile(resp.id_token, function (err, profile) {
-      callback(err, profile, resp.id_token, resp.access_token, resp.state, resp.refresh_token);
+      callback(err, profile, prepareResult(resp));
     });
   }
 
@@ -1183,7 +1183,7 @@ Auth0.prototype.loginWithSocialAccessToken = function (options, callback) {
 
   function enrichGetProfile(resp, callback) {
     _this.getProfile(resp.id_token, function (err, profile) {
-      callback(err, profile, resp.id_token, resp.access_token, resp.state, resp.refresh_token);
+      callback(err, profile, prepareResult(resp));
     });
   }
 
@@ -1825,6 +1825,12 @@ Auth0.prototype.verifySMSCode = function(attrs, cb) {
   delete attrs.code;
   return this.login(attrs, cb);
 };
+
+function prepareResult(result) {
+  return !result || typeof result !== "object"
+    ? undefined
+    : result;
+}
 
 /**
  * Expose `Auth0` constructor

--- a/test/passwordless.tests.js
+++ b/test/passwordless.tests.js
@@ -20,6 +20,8 @@ var xhrSupportPrefix = xhrSupport ? '' : 'not ';
  * Test User and Password
  */
 
+var idToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2xvZ2luLmF1dGgwLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDExODMwNDIzMTY0MDMwMTY4NTU3OSIsImF1ZCI6IjBIUDcxR1NkNlB1b1JZSjNEWEtkaVhDVVVkR21CYnVwIiwiZXhwIjoxMzgwMjU4NzU4LCJpYXQiOjEzODAyMjI3NTgsImNsaWVudElEIjoiMEhQNzFHU2Q2UHVvUllKM0RYS2RpWENVVWRHbUJidXAiLCJlbWFpbCI6Impvc2Uucm9tYW5pZWxsb0BxcmFmdGxhYnMuY29tIiwiZmFtaWx5X25hbWUiOiJSb21hbmllbGxvIiwiZ2VuZGVyIjoibWFsZSIsImdpdmVuX25hbWUiOiJKb3NlIiwiaWRlbnRpdGllcyI6W3siYWNjZXNzX3Rva2VuIjoieWEyOS5BSEVTNlpUSllmQnN3a1NFbUU2YTQ2SlpHYVgxV1Jqc2ZrUzd5Vm81RXNPdktKWVhnenpEZl9ZUiIsInByb3ZpZGVyIjoiZ29vZ2xlLW9hdXRoMiIsInVzZXJfaWQiOiIxMTgzMDQyMzE2NDAzMDE2ODU1NzkiLCJjb25uZWN0aW9uIjoiZ29vZ2xlLW9hdXRoMiIsImlzU29jaWFsIjp0cnVlfV0sImxvY2FsZSI6ImVuIiwibmFtZSI6Ikpvc2UgUm9tYW5pZWxsbyIsIm5pY2tuYW1lIjoiam9zZS5yb21hbmllbGxvIiwicGljdHVyZSI6Imh0dHBzOi8vbGg2Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tcF81dUwxTDFkdkUvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQlEvaVBIRUQ0ajlxblkvcGhvdG8uanBnIiwidXNlcl9pZCI6Imdvb2dsZS1vYXV0aDJ8MTE4MzA0MjMxNjQwMzAxNjg1NTc5In0";
+
 describe('Auth0 - Passwordless', function () {
   afterEach(function () {
     this.server.restore();
@@ -297,7 +299,7 @@ describe('Auth0 - Passwordless', function () {
           this.server.respondWith('POST', 'https://' + this.domain + '/oauth/ro', [
             200,
             { 'Content-Type': 'application/json' },
-            '{}'
+            '{"id_token": "' + idToken + '"}'
           ]);
           // XXX Avoid fetching the profile
           this.auth0.getProfile = function(id_token, callback) {
@@ -309,7 +311,7 @@ describe('Auth0 - Passwordless', function () {
           // TODO test JSONP request
           if (!xhrSupport) return done();
 
-          this.auth0.login({ phoneNumber: this.phoneNumber, passcode: this.passcode }, function (err, profile) {
+          this.auth0.login({ phoneNumber: this.phoneNumber, passcode: this.passcode }, function (err, result) {
             expect(err).to.be(null);
             done();
           });

--- a/test/tests.js
+++ b/test/tests.js
@@ -322,7 +322,7 @@ describe('Auth0', function () {
       });
 
       var result = auth0.parseHash(hash);
-      expect(result.profile.name).to.eql('Jose Romaniello');
+      expect(result.idTokenData.name).to.eql('Jose Romaniello');
       expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
       expect(result.refreshToken).to.eql('gonto');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
@@ -339,7 +339,7 @@ describe('Auth0', function () {
       });
 
       var result = auth0.parseHash(hash);
-      expect(result.profile.name).to.eql('Jose Romaniello');
+      expect(result.idTokenData.name).to.eql('Jose Romaniello');
       expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -323,8 +323,8 @@ describe('Auth0', function () {
 
       var result = auth0.parseHash(hash);
       expect(result.profile.name).to.eql('Jose Romaniello');
-      expect(result.access_token).to.eql('jFxsZUQTJXXwcwIm');
-      expect(result.refresh_token).to.eql('gonto');
+      expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
+      expect(result.refreshToken).to.eql('gonto');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
 
     });
@@ -340,7 +340,7 @@ describe('Auth0', function () {
 
       var result = auth0.parseHash(hash);
       expect(result.profile.name).to.eql('Jose Romaniello');
-      expect(result.access_token).to.eql('jFxsZUQTJXXwcwIm');
+      expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
 
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -322,7 +322,7 @@ describe('Auth0', function () {
       });
 
       var result = auth0.parseHash(hash);
-      expect(result.idTokenData.name).to.eql('Jose Romaniello');
+      expect(result.idTokenPayload.name).to.eql('Jose Romaniello');
       expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
       expect(result.refreshToken).to.eql('gonto');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
@@ -339,7 +339,7 @@ describe('Auth0', function () {
       });
 
       var result = auth0.parseHash(hash);
-      expect(result.idTokenData.name).to.eql('Jose Romaniello');
+      expect(result.idTokenPayload.name).to.eql('Jose Romaniello');
       expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
       expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
 

--- a/test/user-and-pass.tests.js
+++ b/test/user-and-pass.tests.js
@@ -48,26 +48,26 @@ describe('Auth0 - User And Passwords', function () {
           username: 'testttt@wrong.com',
           password: '12345',
           sso:      false
-        }, function (err, profile) {
+        }, function (err, result) {
           expect(err.status).to.equal(400);
           expect(err.message).to.equal('invalid_connection');
-          expect(profile).not.to.be.ok();
+          expect(result).not.to.be.ok();
           done();
         });
       });
 
-      it('should return profile after successfull authentication', function (done) {
+      it('should return the authentication result after successfull authentication', function (done) {
         auth0.login({
           connection: 'tests',
           username: 'johnfoo@gmail.com',
           password: '12345',
           sso: false
-        }, function (err, profile, id_token, access_token) {
-          expect(profile.name).to.eql('John Foo');
-          expect(profile.foo).to.eql('bar');
-          expect(profile.identities.length).to.eql(1);
-          expect(id_token).to.exist;
-          expect(access_token).to.exist;
+        }, function (err, result) {
+          // expect(profile.name).to.eql('John Foo');
+          // expect(profile.foo).to.eql('bar');
+          // expect(profile.identities.length).to.eql(1);
+          expect(result.idToken).to.exist;
+          expect(result.accessToken).to.exist;
           done();
         });
       });
@@ -79,13 +79,13 @@ describe('Auth0 - User And Passwords', function () {
           password: '12345',
           offline_mode: true,
           sso: false
-        }, function (err, profile, id_token, access_token, state, refresh_token) {
-          expect(profile.name).to.eql('John Foo');
-          expect(profile.foo).to.eql('bar');
-          expect(profile.identities.length).to.eql(1);
-          expect(id_token).to.exist;
-          expect(refresh_token).to.exist;
-          expect(access_token).to.exist;
+        }, function (err, result) {
+          // expect(profile.name).to.eql('John Foo');
+          // expect(profile.foo).to.eql('bar');
+          // expect(profile.identities.length).to.eql(1);
+          expect(result.idToken).to.exist;
+          expect(result.refreshToken).to.exist;
+          expect(result.accessToken).to.exist;
           done();
         });
       });
@@ -96,12 +96,12 @@ describe('Auth0 - User And Passwords', function () {
           username: '    johnfoo+2@gmail.com     ',
           password: '12345',
           sso:      false
-        }, function (err, profile, id_token, access_token) {
-          expect(profile.name).to.eql('John Foo');
-          expect(profile.foo).to.eql('bar');
-          expect(profile.identities.length).to.eql(1);
-          expect(id_token).to.exist;
-          expect(access_token).to.exist;
+        }, function (err, result) {
+          // expect(profile.name).to.eql('John Foo');
+          // expect(profile.foo).to.eql('bar');
+          // expect(profile.identities.length).to.eql(1);
+          expect(result.idToken).to.exist;
+          expect(result.accessToken).to.exist;
           done();
         });
       });
@@ -180,22 +180,23 @@ describe('Auth0 - User And Passwords', function () {
 
     describe('with resource owner authentication', function () {
 
-      it('should return profile after successfull signup', function (done) {
+      it('should return auth result after successfull signup', function (done) {
         auth0.signup({
           connection: 'tests',
           username:   'johnfoo@gmail.com',
           password:   '12345',
           sso:        false
-        }, function (err, profile, id_token, access_token) {
-          expect(profile.name).to.eql('John Foo');
-          expect(profile.identities.length).to.eql(1);
-          expect(id_token).to.exist;
-          expect(access_token).to.exist;
+        }, function (err, result) {
+          // expect(profile.name).to.eql('John Foo');
+          // expect(profile.identities.length).to.eql(1);
+          expect(result).to.be.ok();
+          expect(result.idToken).to.be.ok();
+          expect(result.accessToken).to.be.ok();
           done();
         });
       });
 
-      it('should not return profile after successfull signup if auto_login is false', function (done) {
+      it('should not return auth result after successfull signup if auto_login is false', function (done) {
         auth0._renderAndSubmitWSFedForm = function () {
           done(new Error('this should not be called'));
         };
@@ -206,8 +207,9 @@ describe('Auth0 - User And Passwords', function () {
           password:   '12345',
           auto_login: false,
           sso: false
-        }, function (err, profile) {
-          done(profile);
+        }, function (err, result) {
+          expect(result).to.be(undefined);
+          done();
         });
       });
 
@@ -217,9 +219,9 @@ describe('Auth0 - User And Passwords', function () {
           username:   'johnfoo@gmail.com',
           password:   '12345',
           sso:        false
-        }, function (err, profile) {
+        }, function (err, result) {
           expect(err).to.be(null);
-          expect(profile).to.be.ok();
+          expect(result).to.be.ok();
           done();
         });
       });
@@ -233,13 +235,16 @@ describe('Auth0 - User And Passwords', function () {
           email: username + '@gmail.com',
           password:   '12345',
           sso: false
-        }, function (err, profile) {
+        }, function (err, result) {
           expect(err).to.be(null);
-          expect(profile).to.have.property('username');
-          expect(profile).to.have.property('email');
-          expect(profile.username).to.be(username);
-          expect(profile.email).to.be(username + '@gmail.com');
-          done();
+          auth0.getProfile(result.idToken, function(err, profile) {
+            expect(err).to.be(null);
+            expect(profile).to.have.property('username');
+            expect(profile).to.have.property('email');
+            expect(profile.username).to.be(username);
+            expect(profile.email).to.be(username + '@gmail.com');
+            done();
+          });
         });
       });
 


### PR DESCRIPTION
- Stop fetching the profile automatically after a successful login in popup mode.
- Pass a single object with the `result` of the login to the callback in popup mode. This object has properties for the arguments that were passed previously, with the exception of `profile` because it is no longer fetched automatically. The `result` object has the same properties as the returned value of `parseHash`.
- Most of the properties of the `parseHash` return value have been renamed.

|old name|new name|
|------------|--------------|
|access_token|accessToken|
|id_token|idToken|
|profile|idTokenPayload|
|refresh_token|refreshToken|
|state|state|
