### PR TITLE
API calls clean up

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,10 +487,13 @@ Auth0.prototype.signup = function (options, callback) {
   var opts = {
     client_id: this._clientID,
     redirect_uri: this._getCallbackURL(options),
-    username: trim(options.username || ''),
     email: trim(options.email || options.username || ''),
     tenant: this._domain.split('.')[0]
   };
+
+  if (typeof options.username === 'string') {
+     opts.username = trim(options.username);
+   }
 
   var query = xtend(this._getMode(options), options, opts);
 

--- a/index.js
+++ b/index.js
@@ -585,8 +585,7 @@ Auth0.prototype.changePassword = function (options, callback) {
     tenant:         this._domain.split('.')[0],
     client_id:      this._clientID,
     connection:     options.connection,
-    username:       trim(options.username || ''),
-    email:          trim(options.email || options.username || ''),
+    email:          trim(options.email || '')
   };
 
   if (typeof options.password === "string") {

--- a/index.js
+++ b/index.js
@@ -1044,7 +1044,7 @@ Auth0.prototype.loginWithUsernamePasswordAndSSO = function (options, callback) {
       clientID:               this._clientID,
       options: {
         // TODO What happens with i18n?
-        username:   options.username,
+        username:   trim(options.username || options.email || ''),
         password:   options.password,
         connection: options.connection,
         state:      options.state,

--- a/index.js
+++ b/index.js
@@ -587,9 +587,11 @@ Auth0.prototype.changePassword = function (options, callback) {
     connection:     options.connection,
     username:       trim(options.username || ''),
     email:          trim(options.email || options.username || ''),
-    password:       options.password
   };
 
+  if (typeof options.password === "string") {
+    query.password = options.password;
+  }
 
   function fail (status, resp) {
     var error = new LoginError(status, resp);

--- a/test/user-and-pass.tests.js
+++ b/test/user-and-pass.tests.js
@@ -306,10 +306,9 @@ describe('Auth0 - User And Passwords', function () {
   describe('Change Password', function () {
     // TODO: add a test to check that the user can provide a username or email, when `requires_username` is enabled
 
-    it('should fail when the username is null', function (done) {
+    it('should fail when there is no email', function (done) {
       auth0.changePassword({
         connection: 'tests',
-        username:   null,
         password:   '12345'
       }, function (err) {
         expect(err.status).to.equal(400);
@@ -323,18 +322,7 @@ describe('Auth0 - User And Passwords', function () {
     it('should return OK after successfull operation', function (done) {
       auth0.changePassword({
         connection: 'tests',
-        username:   'johnfoo@contoso.com',
-        password:   '12345'
-      }, function (err) {
-        expect(err).to.be(null);
-        done();
-      });
-    });
-
-    it('should trim username before operation', function (done) {
-      auth0.changePassword({
-        connection: 'tests',
-        username:     '    johnfoo@gmail.com    ',
+        email:      'johnfoo@contoso.com',
         password:   '12345'
       }, function (err) {
         expect(err).to.be(null);
@@ -371,7 +359,7 @@ describe('Auth0 - User And Passwords', function () {
 
        auth0.changePassword({
          connection: 'tests',
-         username:   'johnfoo@contoso.com',
+         email:      'johnfoo@contoso.com',
          password:   '12345'
        }, function (err) {
          expect(err).to.not.be(null);


### PR DESCRIPTION
- Fixes a bug that prevented logging in with an email using a database connection with SSO enabled.
- Don't send the username param to _/dbconnections/change_password_, it is not needed nor documented.
- Send the password param to _/dbconnections/change_password_ only when it is provided, given it is only used for the previous flow. The `changePassword` method will ignore it.
- Send the username param to _/dbconnections/signup_ only when it is provided, 