### PR TITLE
Add new response options

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,32 @@ var auth0 = new Auth0({
 
 Both `responseType` and `responseMode` options were added in version `7.2.0`. In previous versions, a subset of the functionality of this options was available through `callbackOnLocationHash`. `responseType: 'code'` is equivalent to `callbackOnLocationHash: false` and `responseType: 'token'` is equivalent to `callbackOnLocationHash: true`. The `callbackOnLocationHash` option is still available for compatibility reasons, but it has been deprecated and will be removed in version `8.0.0`. Also note that is not possible to use `callbackOnLocationHash` and `responseType` at the same time.
 
+```js
+// The next two snippets are equivalent, and a code will be included in the
+// callbackURL after a successful login
+var auth0 = new Auth0({
+  // ...
+  responseType: 'code'
+});
+
+var auth0 = new Auth0({
+  // ...
+  callbackOnLocationHash: false
+});
+
+// The next two snippets are equivalent, and a token will be included in the
+// callbackURL after a successful login
+var auth0 = new Auth0({
+  // ...
+  responseType: 'token'
+});
+
+var auth0 = new Auth0({
+  // ...
+  callbackOnLocationHash: true
+});
+```
+
 ### Change Password (database connections):
 
 ```js

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Construct a new instance of the Auth0 client as follows:
     domain:       'mine.auth0.com',
     clientID:     'dsa7d77dsa7d7',
     callbackURL:  'http://my-app.com/callback',
-    callbackOnLocationHash: true
+    responseType: 'token'
   });
 
   //...
@@ -312,7 +312,7 @@ auth0.login({
 
 ##### Single Page Apps
 
-If you're building a SPA (Single Page Application) and using Redirect Mode, then your `callbackURL` should send the user back to the same page.  And because the `callbackOnLocationHash` initialization option was set to `true`, Auth0 will also append a hash to that URL that will contain an `access_token` and `id_token` (the JWT).  After control returns to your app, the full user profile can be retrieved via the `parseHash` and `getProfile` methods:
+If you're building a SPA (Single Page Application) and using Redirect Mode, then your `callbackURL` should send the user back to the same page.  And because the `responseType` initialization option was set to `'token'`, Auth0 will also append a hash to that URL that will contain an `access_token` and `id_token` (the JWT).  After control returns to your app, the full user profile can be retrieved via the `parseHash` and `getProfile` methods:
 
 ```js
 $(function () {
@@ -352,14 +352,14 @@ If there is no hash, `result` will be null.  If the hash contains the JWT, the `
 
 ##### Regular Web Apps
 
-If you're building a regular web application (HTML pages rendered on the server), then `callbackURL` should point to a server-side endpoint that will process the successful login, primarily to set some sort of session cookie.  In this scenario you should make sure the `callbackOnLocationHash` option is `false` (or just not specified) when the Auth0 client is created:
+If you're building a regular web application (HTML pages rendered on the server), then `callbackURL` should point to a server-side endpoint that will process the successful login, primarily to set some sort of session cookie.  In this scenario you should make sure the `responseType` option is `'code'` (or just not specified) when the Auth0 client is created:
 
 ```js
 var auth0 = new Auth0({
   domain:       'mine.auth0.com',
   clientID:     'dsa7d77dsa7d7',
   callbackURL:  'http://my-app.com/callback'
-  // callbackOnLocationHash not set (defaults to false)
+  // responseType not set (defaults to 'code')
 });
 ```
 
@@ -373,7 +373,7 @@ Besides Redirect Mode, the `login` method also supports Popup Mode, which you en
 
 > **WARNING**: While Popup Mode does have the advantage of preserving page state, it has some issues. Often times users have popup blockers that prevent the login page from even displaying. There are also known issues with mobile browsers. For example, in recent versions of Chrome on iOS, the login popup does not get closed properly after login (see an example [here](https://github.com/auth0/lock/issues/71)). For these reasons, we encourage developers to favor Redirect Mode over Popup Mode, even with Single Page Apps.
 
-In Popup Mode you also have no need to be redirected back to the application, since, once the user has logged in, the popup is simply closed.  Instead Auth0 uses the `login` method's `callback` argument to return control to your client-side application, for both failed and successful logins.  Along with the `err` argument, `callback` should also contain arguments `profile, id_token, access_token, state` (and optionally `refresh_token` if the `offline_access` scope has been requested):
+In Popup Mode you also have no need to be redirected back to the application, since, once the user has logged in, the popup is simply closed.  Instead Auth0 uses the `login` method's `callback` argument to return control to your client-side application, for both failed and successful logins.  Along with the `err` argument, `callback` should also receive a `result` argument with the following properties: `idTokenPayload, idToken, accessToken, state` (and optionally `refreshToken` if the `offline_access` scope has been requested):
 
 ```js
 auth0.login({
@@ -481,6 +481,33 @@ function(err) {
 If the login succeeds, Auth0 will redirect to your `callbackURL` and if it fails, control will be given to the `callback`.
 
 And if you don't want that redirect to occur (i.e. you have a Single Page App), you can use a `callback` argument that takes the additional parameters (like what's shown in [Popup Mode](#popup-mode)), and control will go to your callback function with a failed or successful login.
+
+### Response configuration
+
+By default, after a successful login, the browser is redirected back to the `callbackURL` with an authorization `code` included in the `query` string. This `code` is then used by a server to obtain an access token. The access token can be obtained directly if you provide the `responseType: 'token'` option. In this case the access token will be included in the fragment (or hash) part of the `callbackURL`. Finally, you can specify `responseType: 'id_token'` if you just need an `id_token`.
+
+```js
+var auth0 = new Auth0({
+  domain:       'mine.auth0.com',
+  clientID:     'dsa7d77dsa7d7',
+  callbackURL:  'http://my-app.com/callback',
+  responseType: 'token' // also 'id_token' and 'code' (default)
+});
+```
+
+Besides being included in the url, the code or the tokens can be encoded as HTML form and transmitted via an HTTP POST request to the `callbackUrl`. The `responseMode: 'form_post'` option needs to be used to activate this flow.
+
+```js
+var auth0 = new Auth0({
+  domain:       'mine.auth0.com',
+  clientID:     'dsa7d77dsa7d7',
+  callbackURL:  'http://my-app.com/callback',
+  responseMode: 'form_post',
+  responseType: 'token' // also 'id_token' and 'code' (default)
+});
+```
+
+Both `responseType` and `responseMode` options were added in version `7.2.0`. In previous versions, a subset of the functionality of this options was available through `callbackOnLocationHash`. `responseType: 'code'` is equivalent to `callbackOnLocationHash: false` and `responseType: 'token'` is equivalent to `callbackOnLocationHash: true`. The `callbackOnLocationHash` option is still available for compatibility reasons, but it has been deprecated and will be removed in version `8.0.0`. Also note that is not possible to use `callbackOnLocationHash` and `responseType` at the same time.
 
 ### Change Password (database connections):
 

--- a/index.js
+++ b/index.js
@@ -204,7 +204,8 @@ Auth0.prototype._getResponseType = function(opts) {
 };
 
 Auth0.prototype._getCallbackOnLocationHash = function(options) {
-  return this._getResponseType(options) !== "code";
+  return this._getResponseMode(options) !== "form_post"
+    && this._getResponseType(options) !== "code";
 };
 
 Auth0.prototype._getResponseMode = function(opts) {

--- a/index.js
+++ b/index.js
@@ -174,6 +174,18 @@ function Auth0 (options) {
     this._responseType = "code";
   }
 
+  if (options.hasOwnProperty("responseMode")
+       && !this._providedCallbackOnLocationHash) {
+    this._responseMode = options.responseMode;
+  }
+
+  if (options.hasOwnProperty("responseMode")
+       && this._providedCallbackOnLocationHash
+       && console
+       && console.warn) {
+    console.warn("Ignoring responseMode option because callbackOnLocationHash was already provided. Both can't be used at the same time.");
+  }
+
   this._cordovaSocialPlugins = {
     facebook: this._phonegapFacebookLogin
   };
@@ -242,6 +254,20 @@ Auth0.prototype._getResponseType = function(options) {
 
 Auth0.prototype._getCallbackOnLocationHash = function(options) {
   return this._getResponseType(options) !== "code";
+};
+
+Auth0.prototype._getResponseMode = function(opts) {
+  var responseMode = this._responseMode;
+
+  if (!this._providedCallbackOnLocationHash
+       && opts
+       && opts.hasOwnProperty("responseMode")) {
+    responseMode = opts.responseMode;
+  }
+
+  return responseMode === "form_post"
+    ? "form_post"
+    : null;
 };
 
 Auth0.prototype._getCallbackURL = function(options) {

--- a/index.js
+++ b/index.js
@@ -1942,6 +1942,13 @@ Auth0.prototype._parseResponseType = function(opts, setFlags) {
     warn("The callbackOnLocationHash option will be ignored. The responseType option was provided to the constructor and they can't be mixed.");
   }
 
+  if (!this._providedCallbackOnLocationHash
+       && !opts.hasOwnProperty("callbackOnLocationHash")
+       && opts.responseType
+       && !validResponseType(opts.responseType)) {
+    warn("The responseType option will be ignored. Its valid values are \"code\", \"id_token\", \"token\" or any combination of them.");
+  }
+
   var result = undefined;
 
   if (!this._providedResponseOptions
@@ -1949,10 +1956,10 @@ Auth0.prototype._parseResponseType = function(opts, setFlags) {
     result = callbackOnLocationHashToResponseType(opts.callbackOnLocationHash);
   }
 
-  // TODO: validate responseType
   if (!this._providedCallbackOnLocationHash
        && !opts.hasOwnProperty("callbackOnLocationHash")
-       && null != opts.responseType) {
+       && opts.responseType
+       && validResponseType(opts.responseType)) {
     result = opts.responseType;
   }
 
@@ -1982,8 +1989,14 @@ Auth0.prototype._parseResponseMode = function(opts, setFlags) {
 
   var result = undefined;
 
-  // TODO: validate responseMode
-  if (!this._providedCallbackOnLocationHash && null != opts.responseMode) {
+  if (!this._providedCallbackOnLocationHash
+       && opts.responseMode
+       && !validResponseMode(opts.responseMode)) {
+    warn("The responseMode option will be ignored. Its only valid value is \"form_post\".");
+  }
+
+  if (!this._providedCallbackOnLocationHash
+       && validResponseMode(opts.responseMode)) {
     result = opts.responseMode;
   }
 
@@ -1993,6 +2006,24 @@ Auth0.prototype._parseResponseMode = function(opts, setFlags) {
 function callbackOnLocationHashToResponseType(x) {
   return x ? "token" : "code";
 }
+
+function validResponseType(str) {
+  if (typeof str !== "string") return false;
+
+  var RESPONSE_TYPES = ["code", "id_token", "token"];
+  var parts = str.split(" ");
+
+  for (var i = 0; i < parts.length; i++) {
+    if (RESPONSE_TYPES.indexOf(parts[i]) === -1) return false;
+  }
+
+  return parts.length >= 1;
+}
+
+function validResponseMode(str) {
+  return str === "form_post";
+}
+
 
 function warn(str) {
   if (console && console.warn) {

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ Auth0.prototype._redirect = function (url) {
   global.window.location = url;
 };
 
-Auth0.prototype._getCallbackOnLocationHash = function(options) {
+Auth0.prototype._getResponseType = function(options) {
   var responseType = this._responseType;
 
   if (!this._providedResponseType
@@ -237,7 +237,11 @@ Auth0.prototype._getCallbackOnLocationHash = function(options) {
     responseType = options.responseType;
   }
 
-  return responseType !== "code";
+  return responseType;
+};
+
+Auth0.prototype._getCallbackOnLocationHash = function(options) {
+  return this._getResponseType(options) !== "code";
 };
 
 Auth0.prototype._getCallbackURL = function(options) {
@@ -286,7 +290,7 @@ Auth0.prototype._renderAndSubmitWSFedForm = function (options, formHtml) {
 Auth0.prototype._getMode = function (options) {
   return {
     scope: 'openid',
-    response_type: this._getCallbackOnLocationHash(options) ? 'token' : 'code'
+    response_type: this._getResponseType(options)
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -442,11 +442,17 @@ Auth0.prototype.parseHash = function (hash) {
   hash = hash || window.location.hash;
   hash = hash.substr(1).replace(/^\//, '');
   var parsed_qs = qs.parse(hash);
+
   if (parsed_qs.hasOwnProperty('error')) {
     var err = {
       error: parsed_qs.error,
       error_description: parsed_qs.error_description
     };
+
+    if (parsed_qs.state) {
+      err.state = parsed_qs.state;
+    }
+
     return err;
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -665,8 +665,13 @@ describe('Auth0', function () {
     });
 
     it('should add offline mode', function () {
-      var queryString = Auth0.prototype._buildAuthorizeQueryString([
-        Auth0.prototype._getMode(), { scope: 'openid offline_access'}
+      var c = new Auth0({
+        clientID: "1",
+         domain: "example.auth0.com",
+         sendSDKClientInfo: false
+       });
+      var queryString = c._buildAuthorizeQueryString([
+        c._getMode(), { scope: 'openid offline_access'}
       ], []);
       expect(queryString).to.equal('scope=openid%20offline_access&response_type=code&device=Browser');
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -310,23 +310,321 @@ describe('Auth0', function () {
     })
   });
 
-  describe('parseHash', function () {
-
-    it('should be able to parse the profile', function () {
-      var hash = '#access_token=jFxsZUQTJXXwcwIm&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2xvZ2luLmF1dGgwLmNvbS8iLCJzdWIiOiJnb29nbGUtb2F1dGgyfDExODMwNDIzMTY0MDMwMTY4NTU3OSIsImF1ZCI6IjBIUDcxR1NkNlB1b1JZSjNEWEtkaVhDVVVkR21CYnVwIiwiZXhwIjoxMzgwMjU4NzU4LCJpYXQiOjEzODAyMjI3NTgsImNsaWVudElEIjoiMEhQNzFHU2Q2UHVvUllKM0RYS2RpWENVVWRHbUJidXAiLCJlbWFpbCI6Impvc2Uucm9tYW5pZWxsb0BxcmFmdGxhYnMuY29tIiwiZmFtaWx5X25hbWUiOiJSb21hbmllbGxvIiwiZ2VuZGVyIjoibWFsZSIsImdpdmVuX25hbWUiOiJKb3NlIiwiaWRlbnRpdGllcyI6W3siYWNjZXNzX3Rva2VuIjoieWEyOS5BSEVTNlpUSllmQnN3a1NFbUU2YTQ2SlpHYVgxV1Jqc2ZrUzd5Vm81RXNPdktKWVhnenpEZl9ZUiIsInByb3ZpZGVyIjoiZ29vZ2xlLW9hdXRoMiIsInVzZXJfaWQiOiIxMTgzMDQyMzE2NDAzMDE2ODU1NzkiLCJjb25uZWN0aW9uIjoiZ29vZ2xlLW9hdXRoMiIsImlzU29jaWFsIjp0cnVlfV0sImxvY2FsZSI6ImVuIiwibmFtZSI6Ikpvc2UgUm9tYW5pZWxsbyIsIm5pY2tuYW1lIjoiam9zZS5yb21hbmllbGxvIiwicGljdHVyZSI6Imh0dHBzOi8vbGg2Lmdvb2dsZXVzZXJjb250ZW50LmNvbS8tcF81dUwxTDFkdkUvQUFBQUFBQUFBQUkvQUFBQUFBQUFBQlEvaVBIRUQ0ajlxblkvcGhvdG8uanBnIiwidXNlcl9pZCI6Imdvb2dsZS1vYXV0aDJ8MTE4MzA0MjMxNjQwMzAxNjg1NTc5In0.Qrhrkp7hCYFyN_Ax9yVPKztuJNFHjnGbyUfLJsccLGU&token_type=bearer&state=Ttct3tBlHDhRnXCv&refresh_token=gonto';
-
-      var auth0 = new Auth0({
-        clientID:     '0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup',
-        callbackURL:  'https://myapp.com/callback',
-        domain:       'login.auth0.com'
+  describe.only('parseHash', function () {
+    context('response_type=token + scope=openid offline_access + state', function() {
+      before(function() {
+        var hash = '#access_token=AdyWpLVbQi2GA0fy&refresh_token=8m8M2Dk7BWsmpyumpguR4ZVKpZDy6bhFrZacaq6kmEVtt&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTYzOTQyLCJpYXQiOjE0NzA5Mjc5NDJ9.KcxIWhnTHeL_kNwUq74ef3REOCFDxiOH_NiNMqNNZks&token_type=Bearer&state=hello';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
       });
 
-      var result = auth0.parseHash(hash);
-      expect(result.idTokenPayload.name).to.eql('Jose Romaniello');
-      expect(result.accessToken).to.eql('jFxsZUQTJXXwcwIm');
-      expect(result.refreshToken).to.eql('gonto');
-      expect(result.state).to.eql('Ttct3tBlHDhRnXCv');
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('AdyWpLVbQi2GA0fy');
+      });
 
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTYzOTQyLCJpYXQiOjE0NzA5Mjc5NDJ9.KcxIWhnTHeL_kNwUq74ef3REOCFDxiOH_NiNMqNNZks');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('copies the refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be('8m8M2Dk7BWsmpyumpguR4ZVKpZDy6bhFrZacaq6kmEVtt');
+      });
+
+      it('copies the sate', function() {
+        expect(this.parsedHash.state).to.be('hello');
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=token + scope=openid offline_access', function() {
+      before(function() {
+        var hash = '#access_token=meZc5MnnwwL0LyZO&refresh_token=Xqs1iD2F4IxL3C9WaOaDllZd5ns411967JPPZubuf8K8H&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MDU2LCJpYXQiOjE0NzA5MjgwNTZ9.zM12OViHQQkSogcW_-CXat_2cOMIHy0JShbbNIxKRkM&token_type=Bearer';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('meZc5MnnwwL0LyZO');
+      });
+
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MDU2LCJpYXQiOjE0NzA5MjgwNTZ9.zM12OViHQQkSogcW_-CXat_2cOMIHy0JShbbNIxKRkM');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('copies the refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be('Xqs1iD2F4IxL3C9WaOaDllZd5ns411967JPPZubuf8K8H');
+      });
+
+      it('doesn\'t include sate', function() {
+        expect(this.parsedHash.state).to.be(undefined);
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=token + scope=openid + state', function() {
+      before(function() {
+        var hash = '#access_token=I6MceMUVoKxyWhJN&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MTIwLCJpYXQiOjE0NzA5MjgxMjB9.tkUFnd9oi5AAo9yraQwkrn5Z1D-G4HX3wzQ1yWSM81g&token_type=Bearer&state=hello';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('I6MceMUVoKxyWhJN');
+      });
+
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MTIwLCJpYXQiOjE0NzA5MjgxMjB9.tkUFnd9oi5AAo9yraQwkrn5Z1D-G4HX3wzQ1yWSM81g');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('copies the sate', function() {
+        expect(this.parsedHash.state).to.be('hello');
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=token + scope=openid', function() {
+      before(function() {
+        var hash = '#access_token=kb1t8RwAmevjnV2F&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MTY5LCJpYXQiOjE0NzA5MjgxNjl9.KC6stFcLPFnEPMmRfRVoM3Fe2WMNLBn68Aa63kyZ5gI&token_type=Bearer';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('kb1t8RwAmevjnV2F');
+      });
+
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0MTY5LCJpYXQiOjE0NzA5MjgxNjl9.KC6stFcLPFnEPMmRfRVoM3Fe2WMNLBn68Aa63kyZ5gI');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('doesn\'t include state', function() {
+        expect(this.parsedHash.state).to.be(undefined);
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=token + state', function() {
+      before(function() {
+        var hash = '#access_token=thu2az95NNmhCfeZ&token_type=Bearer&state=hello';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('thu2az95NNmhCfeZ');
+      });
+
+      it('doesn\'t include an id_token', function() {
+        expect(this.parsedHash.idToken).to.be(undefined);
+      });
+
+      it('doesn\'t decode an id_token', function() {
+        expect(this.parsedHash.idTokenPayload).to.be(undefined);
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('copies the state', function() {
+        expect(this.parsedHash.state).to.be('hello');
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=token', function() {
+      before(function() {
+        var hash = '#access_token=cpiUDP1E8zX1Dfyw&token_type=Bearer';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the access_token', function() {
+        expect(this.parsedHash.accessToken).to.be('cpiUDP1E8zX1Dfyw');
+      });
+
+      it('doesn\'t include an id_token', function() {
+        expect(this.parsedHash.idToken).to.be(undefined);
+      });
+
+      it('doesn\'t decode an id_token', function() {
+        expect(this.parsedHash.idTokenPayload).to.be(undefined);
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('doesn\'t include state', function() {
+        expect(this.parsedHash.state).to.be(undefined);
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=id_token + scope=openid + state', function() {
+      before(function() {
+        var hash = '#id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0NzE0LCJpYXQiOjE0NzA5Mjg3MTR9.mQ-OLmCuoveYeH3PhDBXYJOwq8sSfdOieXzUoZqZT2k&state=hello';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('doesn\'t include an access_token', function() {
+        expect(this.parsedHash.accessToken).to.be(undefined);
+      });
+
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0NzE0LCJpYXQiOjE0NzA5Mjg3MTR9.mQ-OLmCuoveYeH3PhDBXYJOwq8sSfdOieXzUoZqZT2k');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('copies the state', function() {
+        expect(this.parsedHash.state).to.be('hello');
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context('response_type=id_token', function() {
+      before(function() {
+        var hash = '#id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0NzU0LCJpYXQiOjE0NzA5Mjg3NTR9.gsjJQyYJzIShiBcI02i4fsGk68nbSCOLojReI2czI7Y';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('doesn\'t include an access_token', function() {
+        expect(this.parsedHash.accessToken).to.be(undefined);
+      });
+
+      it('copies the id_token', function() {
+        expect(this.parsedHash.idToken).to.be('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2duYW5kcmV0dGEuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MmNhOWYzMGRjMjhkOGQ3YmY3MzRhYSIsImF1ZCI6Iks2bkFFT2dFZVN3b2dDR3Y2TjZtOXdOZlFodmJGQW0wIiwiZXhwIjoxNDcwOTY0NzU0LCJpYXQiOjE0NzA5Mjg3NTR9.gsjJQyYJzIShiBcI02i4fsGk68nbSCOLojReI2czI7Y');
+      });
+
+      it('decodes the id_token', function() {
+        expect(this.parsedHash.idTokenPayload.aud).to.be('K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0');
+      });
+
+      it('doesn\'t include a refresh_token', function() {
+        expect(this.parsedHash.refreshToken).to.be(undefined);
+      });
+
+      it('doesn\'t include state', function() {
+        expect(this.parsedHash.state).to.be(undefined);
+      });
+
+      it('doesn\'t have an error', function() {
+        expect(this.parsedHash.error).to.be(undefined);
+      });
+    });
+
+    context("error + state", function() {
+      before(function() {
+        var hash = '#error=unauthorized&error_description=My%20custom%20error%20message&state=hello';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the error', function() {
+        expect(this.parsedHash.error).to.be('unauthorized');
+      });
+
+      it('copies the error message', function() {
+        expect(this.parsedHash.error_description).to.be('My custom error message');
+      });
+
+      it('copies the state', function() {
+        expect(this.parsedHash.state).to.be('hello');
+      });
+    });
+
+    context("error", function() {
+      before(function() {
+        var hash = '#error=unauthorized&error_description=My%20custom%20error%20message';
+        this.parsedHash = new Auth0({
+          clientID: 'K6nAEOgEeSwogCGv6N6m9wNfQhvbFAm0',
+          domain: 'gnandretta.auth0.com'
+        }).parseHash(hash);
+      });
+
+      it('copies the error', function() {
+        expect(this.parsedHash.error).to.be('unauthorized');
+      });
+
+      it('copies the error message', function() {
+        expect(this.parsedHash.error_description).to.be('My custom error message');
+      });
+
+      it('doesn\'t include state', function() {
+        expect(this.parsedHash.state).to.be(undefined);
+      });
     });
 
     it('should be able to parse the profile (if it starts with a slash)', function () {
@@ -400,21 +698,6 @@ describe('Auth0', function () {
       var result = auth0.parseHash(hash);
       expect(result.error).to.be.equal('invalid_token');
       expect(result.error_description).to.be.equal('The clientID configured (wrong) does not match with the clientID set in the token (0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup, 1JQ82GSd6PuoRYJ3DXKdiXCUUdGmBbup).');
-    });
-
-    it('should be able to parse an error', function () {
-      var hash = '#error=invalid_grant&error_description=this%20is%20a%20cool%20error%20description';
-
-      var auth0 = new Auth0({
-        clientID:     'aaaabcdefgh',
-        callbackURL:  'https://myapp.com/callback',
-        domain:       'aaa.auth0.com'
-      });
-
-      var result = auth0.parseHash(hash);
-      expect(result.error).to.be.equal('invalid_grant');
-      expect(result.error_description).to.be.equal('this is a cool error description');
-
     });
 
     it('should be able to parse an error (if it starts with a slash)', function () {


### PR DESCRIPTION
- Adds the `responseType` and `responseMode` options that should be used instead of `callbackOnLocationHash`.
- Previously `callbackOnLocationHash` was a boolean option that was used to change the `response_type` parameter from the API call from `code` to `token`. Now it can be set with `responseType` to `"code"`, `"token"` and "`id_token`".
- `callbackOnLocationHash` can still be used but is deprecated, and shouldn't be mixed with `responseType` or `responseMode`.
- Before, only the default response mode was used for each response type. With the `responseMode` option the `"form_post"` mode can be selected.
- Update `parseHash` to work with the new `id_token` response.
- Include `state` in case of error of `parseHash`.