### PR TITLE
Stop sending client header when has been disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,9 +214,9 @@ Auth0.prototype._getClientInfoString = function () {
 };
 
 Auth0.prototype._getClientInfoHeader = function () {
-  return {
-    'Auth0-Client': this._getClientInfoString()
-  };
+  return this._sendClientInfo
+    ? { 'Auth0-Client': this._getClientInfoString() }
+    : {};
 };
 
 /**


### PR DESCRIPTION
The `sendSDKClientInfo` option was considered only when sending the client info in the query string.