### PR TITLE
Adapt code depending on window to support Isomorphic bundling

### DIFF
--- a/lib/json-parse.js
+++ b/lib/json-parse.js
@@ -3,6 +3,6 @@
  * exists on `window`
  */
 
-module.exports = 'undefined' === typeof window.JSON
+module.exports = 'undefined' === typeof JSON
   ? require('json-fallback').parse
-  : window.JSON.parse;
+  : JSON.parse;

--- a/lib/same-origin.js
+++ b/lib/same-origin.js
@@ -2,13 +2,13 @@
  * Check for same origin policy
  */
 
-var protocol = window.location.protocol;
-var domain = window.location.hostname;
-var port = window.location.port;
-
 module.exports = same_origin;
 
 function same_origin (tprotocol, tdomain, tport) {
+  var protocol = window.location.protocol;
+  var domain = window.location.hostname;
+  var port = window.location.port;
+
   tport = tport || '';
   return protocol === tprotocol && domain === tdomain && port === tport;
 }


### PR DESCRIPTION
We want to use lock in a isomorphic environment. This requires us to be able to at least require the lock module in nodejs. Currently it is not possible because of several accesses to the `window` variable at require-time. This PR takes care of removing some of these accesses. Other accesses are in:

- reqwest dependency (#181)
- winchan