### PR TITLE
Fix popup mode when no id_token is returned

### DIFF
--- a/index.js
+++ b/index.js
@@ -969,7 +969,7 @@ Auth0.prototype.loginWithPopup = function(options, callback) {
     }
 
     // Handle profile retrieval from id_token and respond
-    if (result.id_token) {
+    if (result.access_token || result.id_token) {
       return callback(null, _this._prepareResult(result));
     }
 
@@ -1926,14 +1926,12 @@ Auth0.prototype._prepareResult = function(result) {
     return;
   }
 
-  var idTokenPayload = result.profile
-    ? result.profile
-    : this.decodeJwt(result.id_token);
+  var decodedIdToken = result.id_token ? this.decodeJwt(result.id_token) : undefined;
 
   return {
     accessToken: result.access_token,
     idToken: result.id_token,
-    idTokenPayload: idTokenPayload,
+    idTokenPayload: result.profile || decodedIdToken,
     refreshToken: result.refresh_token,
     state: result.state
   };


### PR DESCRIPTION
Tested manually with:

```js
<!doctype html>
<html>
<head><title>Popup mode without id_token test</title></head>
<body>
<script src="build/auth0.min.js"></script>
<script>
var auth0 = new Auth0({
	domain: '',
	clientID: '',
	responseType: 'token'
});
function afterLogin(err, result) {
	document.body.innerHTML = `<pre>${JSON.stringify(result, null, 2)}</pre>`;
}
function login() {
	auth0.login({
		popup: true,
		connection: 'google-oauth2',
		scope: ''
	}, afterLogin);
}
function apiLogin() {
	auth0.login({
		popup: true,
		connection: 'google-oauth2',
		scope: 'openid read:favorite_food',
		audience: 'https://myapi.example.com'
	}, afterLogin);
}
</script>
<a onclick="login()" href="#">Log in</a><br/>
<a onclick="apiLogin()" href="#">Log in + authorize to API</a>
</body>
</html>

```

---
- Fixes https://github.com/auth0/auth0.js/issues/205