### PR TITLE
do not arbitrarily strip the first character from hash in parseHash method

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,7 +440,7 @@ Auth0.prototype.decodeJwt = function (jwt) {
 
 Auth0.prototype.parseHash = function (hash) {
   hash = hash || window.location.hash;
-  hash = hash.substr(1).replace(/^\//, '');
+  hash = hash.replace(/^#?\//, '');
   var parsed_qs = qs.parse(hash);
 
   if (parsed_qs.hasOwnProperty('error')) {

--- a/index.js
+++ b/index.js
@@ -440,7 +440,7 @@ Auth0.prototype.decodeJwt = function (jwt) {
 
 Auth0.prototype.parseHash = function (hash) {
   hash = hash || window.location.hash;
-  hash = hash.replace(/^#?\//, '');
+  hash = hash.replace(/^#?\/?/, '');
   var parsed_qs = qs.parse(hash);
 
   if (parsed_qs.hasOwnProperty('error')) {


### PR DESCRIPTION
The `parseHash` method arbitrarily strips the first character from the hash even if this first character is not a `#`.
For example, in angular2 when you retrieve the fragment from an url, you don't get the `#`. You only get the value after the `#`.
So, I removed the `.substr(1)` and added an optional `#` in the regex that remove the first forward-slash from the hash.
