### PR TITLE
Add eslint-plugin-compat to avoid cross-browser issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,12 @@
 {
   "extends": "auth0-base/legacy",
+  "plugins": ["compat"],
+  "env": {
+    "browser": true
+  },
   "rules": {
     "func-names": "off",
-    "no-underscore-dangle": "off"
+    "no-underscore-dangle": "off",
+    "compat/compat": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
   "devDependencies": {
     "codecov": "^1.0.1",
     "component-cdn-uploader": "auth0/component-cdn-uploader#1.1.0",
-    "eslint": "3.7.1",
+    "eslint": "3.12.2",
     "eslint-config-auth0-base": "6.0.0",
+    "eslint-plugin-compat": "^1.0.0",
     "eslint-plugin-import": "1.16.0",
     "expect.js": "^0.2.0",
     "gulp": "^3.9.1",
@@ -64,5 +65,6 @@
     "mainBundleFile": "auth0.min.js",
     "bucket": "assets.us.auth0.com",
     "localPath": "build"
-  }
+  },
+  "browserslist": ["last 2 versions", "ie >= 9"]
 }


### PR DESCRIPTION
`eslint-plugin-compat` right now only validates browser JS APIs compatibility  with caniuse.com. Support for browser JS native APIs compatibility with `@kangax's compat` table is on the way.