### PR TITLE
Fix device parameter not being whitelisted for authorization

### DIFF
--- a/src/helper/parameters-whitelist.js
+++ b/src/helper/parameters-whitelist.js
@@ -26,6 +26,7 @@ var authorize_params = [
   'connection_scope',
   'auth0Client',
   'owp',
+  'device',
 // oauth2
   'client_id',
   'response_type',

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -99,6 +99,18 @@ describe('auth0.authentication', function () {
 
       expect(url).to.be('https://me.auth0.com/authorize?client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fanotherpage.com%2Fcallback2&state=1234&prompt=none');
     })
+
+    it('should return a url using using whitelisted authorization parameter device', function() {
+      var url = this.auth0.buildAuthorizeUrl({
+        responseType: 'token',
+        redirectUri: 'http://anotherpage.com/callback2',
+        prompt: 'none',
+        state: '1234',
+        device: 'my-device'
+      });
+
+      expect(url).to.be('https://me.auth0.com/authorize?device=my-device&client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fanotherpage.com%2Fcallback2&state=1234&prompt=none');
+    })
   })
 
   context('buildAuthorizeUrl with Telemetry', function () {


### PR DESCRIPTION
As per https://auth0.com/docs/tokens/refresh-token when issuing a refresh token it is now mandatory to specify a **device** parameter with any arbitrary value, this PR adds it to the whitelisted authorization parameters.

Currently our regular web application does not recognize the device parameter and keeps failing as a result, the call into auth0.js is being made from [here](https://github.com/auth0/lock/blob/master/src/core/web_api/legacy_api.js#L53).