### PR TITLE
fix to not convert arrays to objects

### DIFF
--- a/src/helper/object.js
+++ b/src/helper/object.js
@@ -87,6 +87,10 @@ function toSnakeCase(object, exceptions) {
 function toCamelCase(object, exceptions) {
   exceptions = exceptions || [];
 
+  if (object instanceof Array) {
+    return object.map(function(obj) { return toCamelCase(obj); });
+  }
+  
   return Object.keys(object).reduce(function (p, key) {
     var newKey = exceptions.indexOf(key) === -1 ? snakeToCamel(key) : key;
     p[newKey] = typeof(object[key]) === 'object' ? toCamelCase(object[key]) : object[key];


### PR DESCRIPTION
Arrays are converted to objects. That's a bug. This should fix it