### PR TITLE
Fixed exception in IframeHandler on postMessage(null, ...)

### DIFF
--- a/src/helper/iframe-handler.js
+++ b/src/helper/iframe-handler.js
@@ -66,7 +66,7 @@ IframeHandler.prototype.loadEventListener = function () {
 IframeHandler.prototype.callbackHandler = function (result) {
   var error = null;
 
-  if (result.error) {
+  if (result && result.error) {
     error = result;
     result = null;
   }


### PR DESCRIPTION
Fixes an exception thrown when `parent.postMessage(null, domain);` is called