### PR TITLE
Ignore posted messages unless the expected key is present

### DIFF
--- a/lib/IframeHandler.js
+++ b/lib/IframeHandler.js
@@ -45,7 +45,9 @@ IframeHandler.prototype.init = function (url) {
   }, this.timeout);
 }
 
-IframeHandler.prototype.messageEventListener = function (e) { 
+IframeHandler.prototype.messageEventListener = function (e) {
+  if (!e.data.hasOwnProperty('accessToken')) return;
+
   this.callbackHandler(e.data);
 
   this.destroy()


### PR DESCRIPTION
In some cases, an unrelated message may be posted before the message with the Auth0 token data. If an unrelated message is received, it is processed and the message handler is destroyed, so subsequent valid messages are not received.

This PR changes the message handler to ignore messages unless the expected `accessToken` key is present.

I've tested this change in v7 with the silentAuthentication method. This change may be needed in v8/master as well.
