### PR TITLE
Deprecation warning: webauth.login → webauth.authorize

### DIFF
--- a/src/web-auth/redirect.js
+++ b/src/web-auth/redirect.js
@@ -18,7 +18,7 @@ function Redirect(client, options) {
  * @method loginWithCredentials
  * @param {Object} options
  * @param {Function} cb
- * @deprecated `webauth.redirect.loginWithCredentials` will be soon deprecated, use `webauth.login` instead.
+ * @deprecated `webauth.redirect.loginWithCredentials` will be soon deprecated, use `webauth.authorize` instead.
  */
 Redirect.prototype.loginWithCredentials = function (options, cb) {
   var usernamePassword;
@@ -37,7 +37,7 @@ Redirect.prototype.loginWithCredentials = function (options, cb) {
     'nonce'
   ]).with(options);
 
-  this.warn.warning('`webauth.redirect.loginWithCredentials` will be soon deprecated, use `webauth.login` instead.');
+  this.warn.warning('`webauth.redirect.loginWithCredentials` will be soon deprecated, use `webauth.authorize` instead.');
 
   assert.check(params, { type: 'object', message: 'options parameter is not valid' }, {
     responseType: { type: 'string', message: 'responseType option is required' }


### PR DESCRIPTION
> `webauth.redirect.loginWithCredentials` will be soon deprecated, use `webauth.login` instead.

This is the warning when trying to use `webauth.redirect.loginWithCredentials` (which is [still in the official docs](https://auth0.com/docs/libraries/auth0js#webauth-authorize-). However, `webauth.login` is nowhere to be found.

However, 2a6ef047d32fa43b57d011dbd5a707456f80aba6 renamed the `.login()` method to `.authorize()`. This pull request fixes the deprecation warning.