### PR TITLE
Only parse cordova callback hash 

### DIFF
--- a/plugins/cordova/popup-handler.js
+++ b/plugins/cordova/popup-handler.js
@@ -1,5 +1,6 @@
 var windowHandler = require('../../src/helper/window');
 var qs = require('../../src/helper/qs');
+var urljoin = require('url-join');
 
 function PopupHandler(webAuth) {
   this.webAuth = webAuth;
@@ -100,24 +101,28 @@ PopupHandler.prototype.startHandler = function (event, cb) {
   if (!this._current_popup) {
     return;
   }
+
+  var callbackUrl = urljoin('https:', this.webAuth.baseOptions.domain, '/mobile');
+
+  if (event.url && !(event.url.indexOf(callbackUrl + '#') === 0)) { return; }
+
   var parts = event.url.split('#');
 
   if (parts.length === 1) {
     return;
   }
 
-  var opts = { hash: parts.pop() };
+  var opts = { hash: parts.pop(), _idTokenVerification: false };
 
   if (this.options.nonce) {
     opts.nonce = this.options.nonce;
   }
 
-  _this._current_popup.kill(true);
-
   this.webAuth.parseHash(
     opts,
     function (error, result) {
       if (error || result) {
+        _this._current_popup.kill(true);
         cb(error, result);
       }
     }

--- a/test/plugins/cordova.test.js
+++ b/test/plugins/cordova.test.js
@@ -103,7 +103,6 @@ describe('auth0.plugins.cordova', function () {
       this.events = {};
       var webAuth = new WebAuth({
         domain: 'wptest.auth0.com',
-        redirectUri: 'http://example.com/callback',
         clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
         responseType: 'token',
         __disableExpirationCheck: true
@@ -163,9 +162,36 @@ describe('auth0.plugins.cordova', function () {
       });
 
       this.events.loadstart({
-        url: 'http://callback.com#access_token=asldkfjahsdlkfjhasd&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&state=theState&refresh_token=kajshdgfkasdjhgfas'
+        url: 'https://wptest.auth0.com/mobile#access_token=asldkfjahsdlkfjhasd&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&state=theState&refresh_token=kajshdgfkasdjhgfas'
+      });
+    });
+
+    it('should return the transaction result after a non matching callback url', function(done) {
+      var _this = this;
+      this.popupHandler.load('https://teest.com', '', { nonce: 'asfd' }, function(err, result) {
+        expect(err).to.be(null);
+        expect(result).to.eql({
+          accessToken: 'asldkfjahsdlkfjhasd',
+          idToken: null,
+          idTokenPayload: null,
+          appStatus: null,
+          refreshToken: null,
+          state: 'theState',
+          expiresIn: null,
+          tokenType: 'Bearer'
+        });
+        expect(_this.events).to.eql({});
+        done();
+      });
+
+      this.events.loadstart({
+        url: 'http://randomsite.com#somerandomhash'
+      });
+      this.events.loadstart({
+        url: 'https://wptest.auth0.com/mobile#access_token=asldkfjahsdlkfjhasd&token_type=Bearer&state=theState'
       });
     })
+
 
     it('should return the transaction error', function(done) {
       var _this = this;
@@ -181,7 +207,7 @@ describe('auth0.plugins.cordova', function () {
       });
 
       this.events.loadstart({
-        url: 'http://callback.com#error=some_error&error_description=with a description'
+        url: 'https://wptest.auth0.com/mobile#error=some_error&error_description=with a description'
       });
     });
 


### PR DESCRIPTION
Ignore the rest of url loaded that do not match cordova's callback and also only close the popup when we either find an error or a result to parse.