### PR TITLE
Added possibility to specify custom popup size

### DIFF
--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -132,7 +132,9 @@ Popup.prototype.authorize = function (options, cb) {
     relayUrl = params.redirectUri;
   }
 
-  popOpts.popupOptions = options.popupOptions;
+  if (options.popupOptions) {
+      popOpts.popupOptions = options.popupOptions;
+  }
 
   if (pluginHandler) {
     params = pluginHandler.processParams(params);

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -132,6 +132,8 @@ Popup.prototype.authorize = function (options, cb) {
     relayUrl = params.redirectUri;
   }
 
+  popOpts.popupOptions = options.popupOptions;
+
   if (pluginHandler) {
     params = pluginHandler.processParams(params);
   }


### PR DESCRIPTION
When we want to use popup.authorize method it 's impossible to customize popup size. 
```
this.auth0.popup.authorize({
            connection: 'facebook',
            redirectUri: 'any',
            popupOptions: {
                width: 200,
                height: 200
            }
        }
```