### PR TITLE
Correct spelling mistake in web-auth JSDoc resulting in incorrect autocomplete suggestions

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -17,7 +17,7 @@ var SilentAuthenticationHandler = require('./silent-authentication-handler');
  * @constructor
  * @param {Object} options
  * @param {String} options.domain
- * @param {String} options.clienID
+ * @param {String} options.clientID
  * @param {String} options.responseType
  * @param {String} options.responseMode
  * @param {String} options.scope


### PR DESCRIPTION
Only cosmetic, but my IDE autocomplete gave an incorrect parameter list.

Thought I'd just fix it rather than make a new bug.