### PR TITLE
Require WinChan on demand to allow this to be used in browserless environments

### DIFF
--- a/src/helper/popup-handler.js
+++ b/src/helper/popup-handler.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable guard-for-in */
-var WinChan = require('winchan');
-
 var windowHandler = require('./window');
 var objectHelper = require('./object');
 var qs = require('qs');
@@ -72,6 +70,7 @@ PopupHandler.prototype.load = function (url, relayUrl, options, cb) {
     popup: this._current_popup
   }).with(options);
 
+  var WinChan = require('winchan');
   var popup = WinChan.open(winchanOptions, function (err, data) {
     _this._current_popup = null;
     return cb(err, data);

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -1,5 +1,4 @@
 var urljoin = require('url-join');
-var WinChan = require('winchan');
 
 var urlHelper = require('../helper/url');
 var assert = require('../helper/assert');
@@ -83,6 +82,7 @@ Popup.prototype.getPopupHandler = function (options, preload) {
  */
 Popup.prototype.callback = function (options) {
   var _this = this;
+  var WinChan = require('winchan');
   WinChan.onOpen(function (popupOrigin, r, cb) {
     _this.webAuth.parseHash(options || {}, function (err, data) {
       return cb(err || data);

--- a/test/helper/popup-handler.test.js
+++ b/test/helper/popup-handler.test.js
@@ -1,6 +1,5 @@
 var expect = require('expect.js');
 var stub = require('sinon').stub;
-var WinChan = require('winchan');
 
 var qs = require('qs');
 var PopupHandler = require('../../src/helper/popup-handler');
@@ -81,6 +80,8 @@ describe('helpers popupHandler', function () {
   });
 
   describe('should open the popup', function () {
+    var WinChan = require('winchan');
+
     before(function(){
       global.window = {};
       global.window.screenX = 500;


### PR DESCRIPTION
I am trying to use this package in a react-native app so that I can programmatically interact with the auth0 api. Annoyingly, the `winchan` package does an isInternetExplorer check on require (https://github.com/mozilla/winchan/blob/ac4b142c34daa84bbcb5d8663fad19ce6394cb18/winchan.js#L21) which causes issues in environments like react-native where `navigator.userAgent` does not exist.