### PR TITLE
Cannot find module 'qs' error - added dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "idtoken-verifier": "^1.0.1",
     "superagent": "^3.3.1",
     "url-join": "^1.1.0",
-    "winchan": "^0.2.0"
+    "winchan": "^0.2.0",
+    "qs": "^6.4.0"
   },
   "devDependencies": {
     "codecov": "^1.0.1",


### PR DESCRIPTION
Got an error when building auth0-js from source:
Error: Cannot find module 'qs' from '/node_modules/auth0-js/src/authentication'

Added the dependency to package.json