### PR TITLE
Add disableExpirationCheck to parameters to WebAuth

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -37,6 +37,7 @@ function WebAuth(options) {
     scope: { optional: true, type: 'string', message: 'scope is not valid' },
     audience: { optional: true, type: 'string', message: 'audience is not valid' },
     leeway: { optional: true, type: 'number', message: 'leeway is not valid' },
+    disableExpirationCheck: { optional: true, type: 'boolean', message: 'disableExpirationCheck is not valid' },
     plugins: { optional: true, type: 'array', message: 'plugins is not valid'},
     _disableDeprecationWarnings: { optional: true, type: 'boolean', message: '_disableDeprecationWarnings option is not valid' },
     _sendTelemetry: { optional: true, type: 'boolean', message: '_sendTelemetry option is not valid' },
@@ -150,7 +151,7 @@ WebAuth.prototype.parseHash = function (options, cb) {
       issuer: this.baseOptions.token_issuer,
       audience: this.baseOptions.clientID,
       leeway: this.baseOptions.leeway || 0,
-      __disableExpirationCheck: this.baseOptions.__disableExpirationCheck
+      __disableExpirationCheck: this.baseOptions.disableExpirationCheck
     });
 
     var decodedToken = verifier.decode(parsedQs.id_token);
@@ -194,7 +195,7 @@ WebAuth.prototype.validateToken = function (token, state, nonce, cb) {
     issuer: this.baseOptions.token_issuer,
     audience: this.baseOptions.clientID,
     leeway: this.baseOptions.leeway || 0,
-    __disableExpirationCheck: this.baseOptions.__disableExpirationCheck
+    __disableExpirationCheck: this.baseOptions.disableExpirationCheck
   });
 
   verifier.verify(token, nonce, function (err, payload) {

--- a/test/helper/iframe-handler.test.js
+++ b/test/helper/iframe-handler.test.js
@@ -88,7 +88,7 @@ describe('helpers iframeHandler', function () {
         clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
         responseType: 'token',
         _sendTelemetry: false,
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
     });
 

--- a/test/plugins/cordova.test.js
+++ b/test/plugins/cordova.test.js
@@ -105,7 +105,7 @@ describe('auth0.plugins.cordova', function () {
         domain: 'wptest.auth0.com',
         clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
         responseType: 'token',
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
       var plugin = new CordovaPlugin();
       plugin.setWebAuth(webAuth);

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -100,7 +100,7 @@ describe('auth0.WebAuth', function () {
         redirectUri: 'http://example.com/callback',
         clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
         responseType: 'token',
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
 
       var data = webAuth.parseHash({
@@ -138,7 +138,7 @@ describe('auth0.WebAuth', function () {
         redirectUri: 'http://example.com/callback',
         clientID: 'ixeOHFhD7NSPxEQK6CFcswjUsa5YkcXS',
         responseType: 'token',
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
 
       var data = webAuth.parseHash({
@@ -175,7 +175,7 @@ describe('auth0.WebAuth', function () {
         redirectUri: 'http://example.com/callback',
         clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
         responseType: 'token',
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
 
       var data = webAuth.parseHash({ nonce: 'asfd' },function(err, data) {
@@ -399,7 +399,7 @@ describe('auth0.WebAuth', function () {
         scope: 'openid name read:blog',
         audience: 'urn:site:demo:blog',
         _sendTelemetry: false,
-        __disableExpirationCheck: true
+        disableExpirationCheck: true
       });
 
       var options = {


### PR DESCRIPTION
There is currently an option in the idtoken-verifier library that allows for disabling the expiration/issued at check of incoming tokens. However, it is preceded by two underscores which indicates (at least to me) that we should not rely on using that. I would like to see this option become part of the documented/versioned API.

The ability to add a `leeway` is nice but does not cover all cases. Especially given the restriction on leeway is no more than one minute. We're not doing any token validation on the client side and I don't particularly like putting the restriction on my users that their clocks be synced. We've received several bug reports of errors because "tokens are issued in the future" even when the user's system clock is synced with NTP. 

This pull request aims to "lock in" the use of the `disableExpirationCheck` parameter so that it doesn't get wiped out in future releases and also doesn't discourage people from using it if they don't want to verify `iat` or `exp` values on id tokens.