### PR TITLE
Add option to filter iframe events to prevent incorrect events triggering callbacks

### DIFF
--- a/example/callback.html
+++ b/example/callback.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <script type="text/javascript">
-      parent.postMessage(window.location.hash, "https://localhost:3000/");
-    </script>
-  </head>
-  <body></body>
+
+<head>
+  <script type="text/javascript">
+    parent.postMessage(window.location.hash, "https://localhost:3000/");
+  </script>
+</head>
+
+<body></body>
+
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -345,7 +345,6 @@
       webAuth.renewAuth({
         usePostMessage: true,
         scope:'',
-        audience: 'https://brucke.auth0.com/userinfo',
         redirectURI: 'https://localhost:3000/example/callback.html'
       },
         htmlConsole.dumpCallback.bind(htmlConsole)

--- a/src/helper/iframe-handler.js
+++ b/src/helper/iframe-handler.js
@@ -1,17 +1,27 @@
 var windowHelper = require('./window');
 
+
 function IframeHandler(options) {
-  this.auth0 = options.auth0;
   this.url = options.url;
   this.callback = options.callback;
   this.timeout = options.timeout || 60 * 1000;
   this.timeoutCallback = options.timeoutCallback || null;
-  this.usePostMessage = options.usePostMessage || false;
+  this.eventListenerType = options.eventListenerType || 'message';
   this.iframe = null;
   this.timeoutHandle = null;
   this._destroyTimeout = null;
   this.transientMessageEventListener = null;
-  this.transientEventListener = null;
+  this.proxyEventListener = null;
+  // If no event identifier specified, set default
+  this.eventValidator = options.eventValidator || {
+    isValid: function () {
+      return true;
+    }
+  };
+
+  if (typeof this.callback !== 'function') {
+    throw new Error('options.callback must be a function');
+  }
 }
 
 IframeHandler.prototype.init = function () {
@@ -22,21 +32,24 @@ IframeHandler.prototype.init = function () {
   this.iframe.style.display = 'none';
   this.iframe.src = this.url;
 
-  if (this.usePostMessage) {
-    // Workaround to avoid using bind that does not work in IE8
-    this.transientMessageEventListener = function (e) {
-      _this.messageEventListener(e);
-    };
+  // Workaround to avoid using bind that does not work in IE8
+  this.proxyEventListener = function (e) {
+    _this.eventListener(e);
+  };
 
-    _window.addEventListener('message', this.transientMessageEventListener, false);
-  } else {
-    // Workaround to avoid using bind that does not work in IE8
-    this.transientEventListener = function () {
-      _this.loadEventListener();
-    };
-
-    this.iframe.addEventListener('load', this.transientEventListener, false);
+  switch (this.eventListenerType) {
+    case 'message':
+      this.eventSourceObject = _window;
+      break;
+    case 'load':
+      this.eventSourceObject = this.iframe;
+      break;
+    default:
+      throw new Error('Unsupported event listener type: ' + this.eventListenerType);
   }
+
+  this.eventSourceObject
+    .addEventListener(this.eventListenerType, this.proxyEventListener, false);
 
   _window.document.body.appendChild(this.iframe);
 
@@ -45,26 +58,18 @@ IframeHandler.prototype.init = function () {
   }, this.timeout);
 };
 
-IframeHandler.prototype.messageEventListener = function (e) {
-  this.destroy();
-  this.callbackHandler(e.data);
-};
 
-IframeHandler.prototype.loadEventListener = function () {
-  var _this = this;
-  _this.callback(null, this.iframe.contentWindow.location.hash);
-};
+IframeHandler.prototype.eventListener = function (event) {
+  var eventData = { event: event, sourceObject: this.eventSourceObject };
 
-IframeHandler.prototype.callbackHandler = function (result) {
-  var error = null;
-
-  if (result && result.error) {
-    error = result;
-    result = null;
+  if (!this.eventValidator.isValid(eventData)) {
+    return;
   }
 
-  this.callback(error, result);
+  this.destroy();
+  this.callback(eventData);
 };
+
 
 IframeHandler.prototype.timeoutHandler = function () {
   this.destroy();
@@ -80,14 +85,11 @@ IframeHandler.prototype.destroy = function () {
   clearTimeout(this.timeoutHandle);
 
   this._destroyTimeout = setTimeout(function () {
-    if (_this.usePostMessage) {
-      _window.removeEventListener('message', _this.transientMessageEventListener, false);
-    } else {
-      _this.iframe.removeEventListener('load', _this.transientEventListener, false);
-    }
-
+    _this.eventSourceObject
+      .removeEventListener(_this.eventListenerType, _this.proxyEventListener, false);
     _window.document.body.removeChild(_this.iframe);
   }, 0);
 };
+
 
 module.exports = IframeHandler;

--- a/src/web-auth/silent-authentication-handler.js
+++ b/src/web-auth/silent-authentication-handler.js
@@ -1,18 +1,24 @@
 var IframeHandler = require('../helper/iframe-handler');
 
-function SilentAuthenticationHandler(auth0, authenticationUrl, timeout) {
-  this.auth0 = auth0;
-  this.authenticationUrl = authenticationUrl;
-  this.timeout = timeout || 60 * 1000;
+function SilentAuthenticationHandler(options) {
+  this.authenticationUrl = options.authenticationUrl;
+  this.timeout = options.timeout || 60 * 1000;
   this.handler = null;
+  this.postMessageDataType = options.postMessageDataType || false;
 }
+
+SilentAuthenticationHandler.create = function (options) {
+  return new SilentAuthenticationHandler(options);
+};
 
 SilentAuthenticationHandler.prototype.login = function (usePostMessage, callback) {
   this.handler = new IframeHandler({
     auth0: this.auth0,
     url: this.authenticationUrl,
-    callback: callback,
+    eventListenerType: usePostMessage ? 'message' : 'load',
+    callback: this.getCallbackHandler(callback, usePostMessage),
     timeout: this.timeout,
+    eventValidator: this.getEventValidator(),
     timeoutCallback: function () {
       callback(null, '#error=timeout&error_description=Timeout+during+authentication+renew.');
     },
@@ -21,5 +27,42 @@ SilentAuthenticationHandler.prototype.login = function (usePostMessage, callback
 
   this.handler.init();
 };
+
+SilentAuthenticationHandler.prototype.getEventValidator = function () {
+  var _this = this;
+  return {
+    isValid: function (eventData) {
+      switch (eventData.event.type) {
+        case 'message':
+          // Default behaviour, return all message events.
+          if (_this.postMessageDataType === false) {
+            return true;
+          }
+
+          return eventData.event.data.type &&
+            eventData.event.data.type === _this.postMessageDataType;
+
+        case 'load': // Fall through to default
+        default:
+          return true;
+      }
+    }
+  };
+};
+
+SilentAuthenticationHandler.prototype.getCallbackHandler = function (callback, usePostMessage) {
+  return function (eventData) {
+    var callbackValue;
+    if (!usePostMessage) {
+      callbackValue = eventData.sourceObject.contentWindow.location.hash;
+    } else if (typeof eventData.event.data === 'object' && eventData.event.data.hash) {
+      callbackValue = eventData.event.data.hash;
+    } else {
+      callbackValue = eventData.event.data;
+    }
+    callback(null, callbackValue);
+  };
+};
+
 
 module.exports = SilentAuthenticationHandler;

--- a/test/helper/iframe-handler.test.js
+++ b/test/helper/iframe-handler.test.js
@@ -5,194 +5,376 @@ var WebAuth = require('../../src/web-auth');
 var windowHelper = require('../../src/helper/window');
 var IframeHandler = require('../../src/helper/iframe-handler');
 
-function stubWindow(event, data) {
-  if (event === 'message') {
-    var iframe = {
+
+function MockEventSourceObject() {
+  this.eventListeners = {
+    'load': [],
+    'message': []
+  };
+
+  this.emitEvent = function (eventType, eventObject) {
+    expect(!!this.eventListeners[eventType]).to.be(true);
+
+    for (var a in this.eventListeners[eventType]) {
+      this.eventListeners[eventType][a](eventObject);
+    }
+  };
+
+  this.addEventListener = function (eventType, callback) {
+    expect(!!this.eventListeners[eventType]).to.be(true);
+
+    this.eventListeners[eventType].push(callback);
+  };
+
+  this.removeEventListener = function (eventType, callback) {
+    expect(!!this.eventListeners[eventType]).to.be(true);
+
+    var index = this.eventListeners[eventType].indexOf(callback);
+    if (index > -1) {
+      this.eventListeners[eventType].splice(index, 1);
+    }
+  };
+
+  this.assimilate = function (object) {
+    var keys = Object.keys(object);
+    for (var a in keys) {
+      this[keys[a]] = object[keys[a]];
+    }
+  };
+}
+
+
+function stubWindow(eventType, data) {
+  var iFrame = new MockEventSourceObject();
+
+  if (eventType === 'message') {
+    iFrame.assimilate({
       id: 'the_iframe',
       style: {}
-    };
-  } else {
-    var iframe = {
+    });
+  } else if (eventType === 'load') {
+    iFrame.assimilate({
       id: 'the_iframe',
       style: {},
       contentWindow: {
         location: {
           hash: data !== undefined ? data : '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&state=theState&refresh_token=kajshdgfkasdjhgfas'
         }
-      },
-      removeEventListener: function (event) {
-        expect(event).to.be(event);
-      },
-      addEventListener: function (event, callback) {
-        expect(event).to.be(event);
-        setTimeout(function(){
-          callback();
-        }, 100)
       }
-    };
+    });
   }
 
-  stub(windowHelper, 'getWindow', function () {
-    return {
-      localStorage: {
-        removeItem: function(key) {
-          expect(key).to.be('com.auth0.auth.theState');
+  var fauxWindow = new MockEventSourceObject();
+  fauxWindow.assimilate({
+    mockObjectStore: {
+      iframe: null
+    },
+    localStorage: {
+      removeItem: function (key) {
+        expect(key).to.be('com.auth0.auth.theState');
+      },
+      getItem: function (key) {
+        expect(key).to.be('com.auth0.auth.theState');
+        return JSON.stringify({
+          nonce: 'asfd',
+          appState: null
+        });
+      }
+    },
+    document: {
+      createElement: function (element) {
+        expect(element).to.be('iframe');
+        return iFrame;
+      },
+      body: {
+        removeChild: function (ele) {
+          expect(ele).to.be(iFrame);
+          expect(fauxWindow.mockObjectStore.iframe).to.be(iFrame);
+          fauxWindow.mockObjectStore.iframe = null;
         },
-        getItem: function(key) {
-          expect(key).to.be('com.auth0.auth.theState');
-          return JSON.stringify({
-            nonce: 'asfd',
-            appState: null
-          });
-        }
-      },
-      addEventListener: function (event, callback) {
-        expect(event).to.be(event);
-        if (data !== false) {
-          setTimeout(function(){
-            callback({
-              data: data || { access_token: '123' }
-            });
-          }, 100)
-        }
-      },
-      removeEventListener: function (event) {
-        expect(event).to.be(event);
-      },
-      document: {
-        createElement: function (element) {
-          expect(element).to.be('iframe');
-          return iframe
-        },
-        body: {
-          removeChild: function(ele) {
-            expect(ele.id).to.be('the_iframe');
-          },
-          appendChild: function (ele) {
-            expect(ele.id).to.be('the_iframe');
-          }
+        appendChild: function (ele) {
+          expect(fauxWindow.mockObjectStore.iframe).to.be(null);
+          expect(ele.id).to.be('the_iframe');
+          fauxWindow.mockObjectStore.iframe = ele;
         }
       }
     }
   });
 
-  return iframe;
+
+  stub(windowHelper, 'getWindow', function () {
+    return fauxWindow;
+  });
+
+  return iFrame;
 }
 
 describe('helpers iframeHandler', function () {
-  context('should render the iframe', function() {
-    before(function () {
-      this.auth0 = new WebAuth({
-        domain: 'wptest.auth0.com',
-        redirectUri: 'http://example.com/callback',
-        clientID: 'gYSNlU4YC4V1YPdqq8zPQcup6rJw1Mbt',
-        responseType: 'token',
-        _sendTelemetry: false,
-        __disableExpirationCheck: true
-      });
+  context('with context', function () {
+
+    afterEach(function () {
+      windowHelper.getWindow.restore();
     });
 
-    afterEach(function(){
-      windowHelper.getWindow.restore();
-    })
 
-    it('and hook to the message event', function (done) {
-
+    it('should create a hidden iframe with a specific url', function () {
       var iframe = stubWindow('message');
-
       var iframeHandler = new IframeHandler({
-        auth0: this.auth0,
-        url: 'http://example.com',
-        callback: function(err,data){
-          expect(iframe.style).to.eql({ display: 'none' });
-          expect(iframe.src).to.be('http://example.com');
-
-          expect(err).to.be(null);
-          expect(data).to.eql({ access_token: '123' });
-
-          setTimeout(done, 100);
-        },
-        timeoutCallback: function(){},
-        usePostMessage: true
+        url: 'my-url',
+        callback: function () {
+        }
       });
+
 
       iframeHandler.init();
+
+      expect(windowHelper.getWindow().document.body);
+      expect(iframe.src).to.be('my-url');
+      expect(iframe.style.display).to.be('none');
     });
 
-    it('and hook to the load event and returns the hash', function (done) {
-
-      var iframe = stubWindow('load');
-
+    it('should callback after a timeout', function () {
+      var iframe = stubWindow('message');
+      var timeOutCalled = false;
       var iframeHandler = new IframeHandler({
-        auth0: this.auth0,
-        url: 'http://example.com',
-        callback: function (err, data) {
-          expect(iframe.style).to.eql({ display: 'none' });
-          expect(iframe.src).to.be('http://example.com');
-
-          expect(data).to.eql(iframe.contentWindow.location.hash);
-
-          setTimeout(done, 100);
+        timeout: 10,
+        timeoutCallback: function () {
+          timeOutCalled = true;
+        },
+        callback: function () {
         }
       });
 
       iframeHandler.init();
+
+      setTimeout(function () {
+        expect(timeOutCalled).to.be(true);
+      }, 20);
     });
 
-    it('and hook to the load event (with invalid hash) should timeout', function (done) {
-      var iframe = stubWindow('load', '');
-
+    it('should add an event listener, adding it to the window for message type events by default', function () {
+      var iframe = stubWindow('message');
       var iframeHandler = new IframeHandler({
-        auth0: this.auth0,
-        url: 'http://example.com',
-        callback: function(err,data){
+        callback: function () {
+        }
+      });
+
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(0);
+      expect(iframe.eventListeners['load'].length).to.be(0);
+      iframeHandler.init();
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(1);
+      expect(iframe.eventListeners['load'].length).to.be(0);
+    });
+
+    it('should add an event listener, adding it to the window for message type events, when specified', function () {
+      var iframe = stubWindow('message');
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'message',
+        callback: function () {
+        }
+      });
+
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(0);
+      expect(iframe.eventListeners['load'].length).to.be(0);
+      iframeHandler.init();
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(1);
+      expect(iframe.eventListeners['load'].length).to.be(0);
+    });
+
+    it('should add an event listener, adding it to the iframe for load type events', function () {
+      var iframe = stubWindow('message');
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'load',
+        callback: function () {
+        }
+      });
+
+      expect(iframe.eventListeners['load'].length).to.be(0);
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(0);
+      iframeHandler.init();
+      expect(iframe.eventListeners['load'].length).to.be(1);
+      expect(windowHelper.getWindow().eventListeners['message'].length).to.be(0);
+    });
+
+    it('should call an event validator for a message event on the window', function () {
+      var iframe = stubWindow('message');
+      var validatorCalled = false;
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'message',
+        eventValidator: {
+          isValid: function (eventData) {
+            validatorCalled = true;
+            expect(eventData.event).to.eql({id: 'my-id'});
+            expect(eventData.sourceObject).to.eql(windowHelper.getWindow());
+          }
         },
-        timeoutCallback: function(){
-          expect(iframe.style).to.eql({ display: 'none' });
-          expect(iframe.src).to.be('http://example.com');
-          setTimeout(done, 100);
-        },
-        timeout: 100
+        callback: function () {
+        }
       });
 
       iframeHandler.init();
+      expect(validatorCalled).to.be(false);
+      windowHelper.getWindow().emitEvent('message', {id: 'my-id'});
+      expect(validatorCalled).to.be(true);
+
     });
 
-    it('and timeout', function (done) {
-      var iframe = stubWindow('message', false);
-
+    it('should call an event validator for a load event on the Iframe', function () {
+      var iframe = stubWindow('load');
+      var validatorCalled = false;
       var iframeHandler = new IframeHandler({
-        auth0: this.auth0,
-        url: 'http://example.com',
-        callback: function(data){
+        eventListenerType: 'load',
+        eventValidator: {
+          isValid: function (eventData) {
+            validatorCalled = true;
+            expect(eventData.event).to.eql({id: 'my-id-2'});
+            expect(eventData.sourceObject).to.eql(iframe);
+          }
         },
-        timeoutCallback: function(){
-          expect(iframe.style).to.eql({ display: 'none' });
-          expect(iframe.src).to.be('http://example.com');
-          setTimeout(done, 100);
-        },
-        usePostMessage: true,
-        timeout: 100
+        callback: function () {
+        }
       });
 
       iframeHandler.init();
+      expect(validatorCalled).to.be(false);
+      iframe.emitEvent('load', {id: 'my-id-2'});
+      expect(validatorCalled).to.be(true);
+
     });
 
-    it('and timeout (without a timeout callback)', function (done) {
-      var iframe = stubWindow('message', false);
-
+    it('should not destroy or callback if an event is not valid', function () {
+      var iframe = stubWindow('message');
+      var destroyCalled = false;
+      var callbackCalled = false;
       var iframeHandler = new IframeHandler({
-        auth0: this.auth0,
-        url: 'http://example.com',
-        callback: function(data){
+        eventListenerType: 'message',
+        callback: function () {
+          callbackCalled = true;
         },
-        usePostMessage: true,
-        timeout: 1
+        eventValidator: {
+          isValid: function (eventData) {
+            return false;
+          }
+        }
+      });
+
+      // Overload the destroy function
+      iframeHandler.destroy = function () {
+        destroyCalled = true;
+      };
+
+      iframeHandler.init();
+
+      windowHelper.getWindow().emitEvent('message');
+
+      expect(callbackCalled).to.eql(false);
+      expect(destroyCalled).to.eql(false);
+    });
+
+
+    it('should destroy and callback with valid data if an event is valid', function (done) {
+      var iframe = stubWindow('message');
+      var destroyCalled = false;
+      var callbackCalled = false;
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'message',
+        callback: function (eventData) {
+          expect(eventData.event).to.eql({id: 'my-event-5'});
+          callbackCalled = true;
+        },
+        eventValidator: {
+          isValid: function (eventData) {
+            return true;
+          }
+        }
+      });
+
+
+      iframeHandler.init();
+
+      windowHelper.getWindow().emitEvent('message', {id: 'my-event-5'});
+
+      expect(callbackCalled).to.eql(true);
+
+      setTimeout(function () {
+        expect(callbackCalled).to.eql(true);
+        expect(windowHelper.getWindow().eventListeners['message'].length).to.be(0);
+        expect(windowHelper.getWindow().mockObjectStore.iframe).to.be(null);
+
+        done();
+      }, 200);
+    });
+    it('default eventValidator should always return true', function () {
+      var iframe = stubWindow('message');
+      var callbackCalled = false;
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'message',
+        callback: function () {
+          callbackCalled = true;
+        },
+        eventValidator: undefined
       });
 
       iframeHandler.init();
 
-      setTimeout(done, 100); // we do not assert anything, just wait to make sure anything fails
+      windowHelper.getWindow().emitEvent('message', {id: 'my-event-5'});
+      expect(callbackCalled).to.eql(true);
+    });
+
+
+    it('should destroy and callback if a timeout occurs', function (done) {
+      var iframe = stubWindow('message');
+      var destroyCalled = false;
+      var callbackCalled = false;
+      
+      var iframeHandler = new IframeHandler({
+        eventListenerType: 'message',
+        timeout: 100,
+        timeoutCallback: function () {
+          callbackCalled = true;
+        },
+        callback: function () {
+        }
+      });
+      
+      iframeHandler.destroy = function () {
+        destroyCalled = true;
+      };
+
+      iframeHandler.init();
+
+      setTimeout(function () {
+        expect(callbackCalled).to.eql(true);
+        expect(destroyCalled).to.eql(true);
+
+        done();
+      }, 200);
+
+    });
+
+    it('should throw an exception if a callback is not specified', function (done) {
+      var iframe = stubWindow('message');
+      try {
+        var iframeHandler = new IframeHandler({});
+      } catch (e) {
+        expect(e.message).to.eql('options.callback must be a function');
+        done();
+      }
+    });
+
+
+    it('should throw an exception if an invalid eventListernerType is specified', function (done) {
+      var iframe = stubWindow('message');
+      try {
+        var iframeHandler = new IframeHandler({
+          eventListenerType: 'invalid',
+          callback: function () {}
+        });
+        iframeHandler.init();
+      } catch (e) {
+        expect(e.message).to.eql('Unsupported event listener type: invalid');
+        done();
+      }
     });
 
   });

--- a/test/web-auth/silent-authentication-handler.test.js
+++ b/test/web-auth/silent-authentication-handler.test.js
@@ -1,0 +1,140 @@
+var expect = require('expect.js');
+var stub = require('sinon').stub;
+
+var WebAuth = require('../../src/web-auth');
+var SilentAuthenticationHandler = require('../../src/web-auth/silent-authentication-handler');
+var IframeHandler = require('../../src/helper/iframe-handler');
+
+var eventEmitter = {
+  emitEvent: function(mockEvent){
+    iframeHandler.callback(mockEvent);
+  }
+};
+var iframeHandler = {};
+
+describe('handlers silent-authentication-handler', function () {
+  context('with context', function () {
+    afterEach(function() {
+      if (IframeHandler.prototype.init.restore) {
+        IframeHandler.prototype.init.restore();
+      }
+    });
+    it('should return correct value for usePostMessage=false', function (done) {
+      stub(IframeHandler.prototype, 'init', function () {
+        iframeHandler.callback = this.callback;
+      });
+      var sah = new SilentAuthenticationHandler({});
+
+      sah.login(false, function(arg1, arg2){
+        expect(arg1).to.be(null);
+        expect(arg2).to.be('my-hash-data');
+        done();
+      });
+
+      eventEmitter.emitEvent({sourceObject: {contentWindow: {location: {hash: 'my-hash-data'}}}});
+    });
+    context('should return correct value for usePostMessage=true', function() {
+      it('when the event payload is an object with a `hash` property', function (done) {
+        stub(IframeHandler.prototype, 'init', function () {
+          iframeHandler.callback = this.callback;
+        });
+        var sah = new SilentAuthenticationHandler({});
+
+        sah.login(true, function(arg1, arg2){
+          expect(arg1).to.be(null);
+          expect(arg2).to.be('my-hash-data-2');
+          done();
+        });
+
+        eventEmitter.emitEvent({event: {data: {hash: 'my-hash-data-2'}}});
+      });
+      it('when the event payload is an object (parsed hash)', function (done) {
+        stub(IframeHandler.prototype, 'init', function () {
+          iframeHandler.callback = this.callback;
+        });
+        var sah = new SilentAuthenticationHandler({});
+
+        sah.login(true, function(arg1, arg2){
+          expect(arg1).to.be(null);
+          expect(arg2).to.eql({foo: 'bar'});
+          done();
+        });
+
+        eventEmitter.emitEvent({event: {data: {foo: 'bar'}}});
+      });
+      it('when the event payload is a string', function (done) {
+        stub(IframeHandler.prototype, 'init', function () {
+          iframeHandler.callback = this.callback;
+        });
+        var sah = new SilentAuthenticationHandler({});
+
+        sah.login(true, function(arg1, arg2){
+          expect(arg1).to.be(null);
+          expect(arg2).to.eql('foobar');
+          done();
+        });
+
+        eventEmitter.emitEvent({event: {data: 'foobar'}});
+      });
+    });
+
+
+
+    it('should positively validate message event types with correct postMessageDataType set', function(){
+      var sah = new SilentAuthenticationHandler({
+        postMessageDataType: 'auth0:silent-authentication'
+      });
+      var validator = sah.getEventValidator();
+
+      expect(validator.isValid({event: {type: 'message', data: {type: 'auth0:silent-authentication'}}}))
+        .to.be(true);
+
+    });
+
+    it('should negatively validate message event types with invalid postMessageDataType', function(){
+      var sah = new SilentAuthenticationHandler({
+        postMessageDataType: 'auth0:silent-authentication'
+      });
+      var validator = sah.getEventValidator();
+
+      expect(validator.isValid({event: {type: 'message', data: {type: 'some unexpected data type'}}}))
+        .to.be(false);
+
+    });
+
+    it('should positively validate message event types with postMessageDataType as false', function(){
+      var sah = new SilentAuthenticationHandler({
+        postMessageDataType: false
+      });
+      var validator = sah.getEventValidator();
+
+      expect(validator.isValid({event: {type: 'message', data: {type: 'some unexpected data type'}}}))
+        .to.be(true);
+
+    });
+
+
+    it('should positively validate message event types with postMessageDataType not set', function(){
+      var sah = new SilentAuthenticationHandler({
+        postMessageDataType: false
+      });
+      var validator = sah.getEventValidator();
+
+      expect(validator.isValid({event: {type: 'message', data: {type: 'some unexpected data type'}}}))
+        .to.be(true);
+
+    });
+
+
+    it('should positively validate load event types', function(){
+      var sah = new SilentAuthenticationHandler({
+        postMessageDataType: false
+      });
+      var validator = sah.getEventValidator();
+
+      expect(validator.isValid({event: {type: 'load'}}))
+        .to.be(true);
+
+    });
+  });
+});


### PR DESCRIPTION
This change fixes an issue with the Iframe handler, where unrelated events were triggering callbacks, which caused undesired behaviour.

* Adds event validation to the Iframe handler, which allows for customised event filtering.
* Shifts responsibility of what to return in the callback from the Iframe handler to the silent authentication handler.
* Moves some logic out of the Iframe handler and in to the authentication handler, hopefully, more clearly defining the responsibilities of each class.