### PR TITLE
Fixed issue in overrides of __tenant and __tenant_issuer

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -79,11 +79,10 @@ function WebAuth(options) {
     : true;
 
   this.baseOptions.tenant =
-    (this.baseOptions.overrides && this.baseOptions.overrides.__tenant) ||
-    this.baseOptions.domain.split('.')[0];
+    (options.overrides && options.overrides.__tenant) || this.baseOptions.domain.split('.')[0];
 
   this.baseOptions.token_issuer =
-    (this.baseOptions.overrides && this.baseOptions.overrides.__token_issuer) ||
+    (options.overrides && options.overrides.__token_issuer) ||
     'https://' + this.baseOptions.domain + '/';
 
   this.transactionManager = new TransactionManager(this.baseOptions.transaction);


### PR DESCRIPTION
The overrides of `__tenant` and `__tenant_issuer` are not mapped correctly when having following config, this PR fixes this.

```
var auth0 = new auth0.WebAuth({
  overrides: {
    __tenant: 'XXX',
    __token_issuer: 'https://XXX.auth0.com/'
  }
});
```