### PR TITLE
Avoid snake casing of metadata on signup

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -25,12 +25,14 @@ function DBConnection(request, options) {
  * @param {String} options.email user email address
  * @param {String} options.password user password
  * @param {String} options.connection name of the connection where the user will be created
+ * @param {Object} [options.userMetadata] additional signup attributes used for creating the user. Will be stored in `user_metadata`
  * @param {signUpCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  */
 DBConnection.prototype.signup = function(options, cb) {
   var url;
   var body;
+  var metadata;
 
   assert.check(
     options,
@@ -47,9 +49,15 @@ DBConnection.prototype.signup = function(options, cb) {
 
   body = objectHelper.merge(this.baseOptions, ['clientID']).with(options);
 
-  body = objectHelper.blacklist(body, ['scope']);
+  metadata = body.user_metadata || body.userMetadata;
+
+  body = objectHelper.blacklist(body, ['scope', 'userMetadata', 'user_metadata']);
 
   body = objectHelper.toSnakeCase(body, ['auth0Client']);
+
+  if (metadata) {
+    body.user_metadata = metadata;
+  }
 
   return this.request.post(url).send(body).end(responseHandler(cb));
 };

--- a/test/authentication/db-connection.test.js
+++ b/test/authentication/db-connection.test.js
@@ -1,9 +1,12 @@
 var expect = require('expect.js');
 var stub = require('sinon').stub;
 
+var RequestMock = require('../mock/request-mock');
 var request = require('superagent');
 
+var RequestBuilder = require('../../src/helper/request-builder');
 var Authentication = require('../../src/authentication');
+var telemetryInfo = new RequestBuilder({}).getTelemetryData();
 
 describe('auth0.authentication', function() {
   context('dbConnection signup options', function() {
@@ -12,8 +15,7 @@ describe('auth0.authentication', function() {
         domain: 'me.auth0.com',
         clientID: '...',
         redirectUri: 'http://page.com/callback',
-        responseType: 'code',
-        _sendTelemetry: false
+        responseType: 'code'
       });
     });
 
@@ -59,6 +61,112 @@ describe('auth0.authentication', function() {
         _this.auth0.dbConnection.signup({ connection: 'bla', email: 'blabla', password: '123456' });
       }).to.throwException(function(e) {
         expect(e.message).to.be('cb parameter is not valid');
+      });
+    });
+
+    context('additional fields', function() {
+      afterEach(function() {
+        request.post.restore();
+      });
+
+      it('should send metadata on signup', function(done) {
+        stub(request, 'post', function(url) {
+          expect(url).to.be('https://me.auth0.com/dbconnections/signup');
+          expect;
+          return new RequestMock({
+            body: {
+              client_id: '...',
+              email: 'the email',
+              password: 'the password',
+              connection: 'the_connection',
+              user_metadata: {
+                firstName: 'Toon',
+                lastName: 'De Coninck'
+              }
+            },
+            headers: {
+              'Content-Type': 'application/json',
+              'Auth0-Client': telemetryInfo
+            },
+            cb: function(cb) {
+              cb(null, {
+                body: {
+                  email: 'the email'
+                }
+              });
+            }
+          });
+        });
+
+        this.auth0.dbConnection.signup(
+          {
+            email: 'the email',
+            password: 'the password',
+            connection: 'the_connection',
+            user_metadata: {
+              firstName: 'Toon',
+              lastName: 'De Coninck'
+            }
+          },
+          function(err, data) {
+            expect(err).to.be(null);
+            expect(data).to.eql({
+              email: 'the email'
+            });
+            done();
+          }
+        );
+      });
+
+      it('should send metadata on signup when using camel case', function(done) {
+        stub(request, 'post', function(url) {
+          expect(url).to.be('https://me.auth0.com/dbconnections/signup');
+          expect;
+          return new RequestMock({
+            body: {
+              client_id: '...',
+              email: 'the email',
+              password: 'the password',
+              connection: 'the_connection',
+              user_metadata: {
+                firstName: 'Toon',
+                lastName: 'De Coninck',
+                last_location: 'Mexico'
+              }
+            },
+            headers: {
+              'Content-Type': 'application/json',
+              'Auth0-Client': telemetryInfo
+            },
+            cb: function(cb) {
+              cb(null, {
+                body: {
+                  email: 'the email'
+                }
+              });
+            }
+          });
+        });
+
+        this.auth0.dbConnection.signup(
+          {
+            email: 'the email',
+            password: 'the password',
+            connection: 'the_connection',
+            userMetadata: {
+              firstName: 'Toon',
+              lastName: 'De Coninck',
+              last_location: 'Mexico'
+            }
+          },
+          function(err, data) {
+            expect(err).to.be(null);
+            expect(data).to.eql({
+              email: 'the email'
+            });
+            done();
+          }
+        );
       });
     });
   });


### PR DESCRIPTION
This could break customers but its a bug since no metadata attributes should be stored with no change