### PR TITLE
Fix example of parseHash in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ auth0.authorize({
 > This method requires that your tokens are signed with **RS256**. Please check our [Migration Guide](https://auth0.com/docs/libraries/auth0js/v8/migration-guide#switching-from-hs256-to-rs256) for more information.
 
 ```js
-auth0.parseHash(window.location.hash, function(err, authResult) {
+auth0.parseHash({hash: window.location.hash}, function(err, authResult) {
   if (err) {
     return console.log(err);
   }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ auth0.authorize({
 > This method requires that your tokens are signed with **RS256**. Please check our [Migration Guide](https://auth0.com/docs/libraries/auth0js/v8/migration-guide#switching-from-hs256-to-rs256) for more information.
 
 ```js
-auth0.parseHash({hash: window.location.hash}, function(err, authResult) {
+auth0.parseHash({ hash: window.location.hash }, function(err, authResult) {
   if (err) {
     return console.log(err);
   }


### PR DESCRIPTION
Passing a string leads to the code looking at `<string>.hash`, seeing that it is undefined, and defaulting to `window.location.hash`.  Which *might* be what you wanted, until it isn't!

Also, why is all of this half-documented in the README rather than pointing to https://auth0.com/docs/libraries/auth0js/v8?  In particular, `options` isn't really fleshed out for any of these.