### PR TITLE
README.md: fix likely typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ From CDN
 From [bower](http://bower.io)
 
 ```sh
-bower install auth0-lock
+bower install auth0-js
 ```
 
 ```html


### PR DESCRIPTION
`auth0-lock` is not the name of the bower package equivalent to `auth0-js`, right?  I know that `auth0-lock` is definitely a separate npm package...