### PR TITLE
console warning when using timeout parameter with renewAuth

### DIFF
--- a/src/helper/parameters-whitelist.js
+++ b/src/helper/parameters-whitelist.js
@@ -28,7 +28,7 @@ var authorizeParams = [
   'owp',
   'device',
   'realm',
-
+  'timeout',
   'protocol',
   '_csrf',
   '_intstate',


### PR DESCRIPTION
When I use the `timeout` parameter with `renewAuth()`, it works as expected, but I also get this bogus warning in the browser console:

> Following parameters are not allowed on the `/authorize` endpoint: [timeout]"

Root cause seems to be that `timeout` was not added to the parameter whitelist when it was implemented by 5b638c8, so I have added it.