### PR TITLE
Remove invalid params from authorize url to eliminate console warnings

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -82,9 +82,8 @@ function WebAuth(options) {
   this.baseOptions = options;
   this.baseOptions.plugins = new PluginHandler(this, this.baseOptions.plugins || []);
 
-  this.baseOptions._sendTelemetry = this.baseOptions._sendTelemetry === false
-    ? this.baseOptions._sendTelemetry
-    : true;
+  this.baseOptions._sendTelemetry =
+    this.baseOptions._sendTelemetry === false ? this.baseOptions._sendTelemetry : true;
 
   this.baseOptions._timesToRetryFailedRequests = options._timesToRetryFailedRequests
     ? parseInt(options._timesToRetryFailedRequests, 0)
@@ -319,7 +318,8 @@ WebAuth.prototype.renewAuth = function(options, cb) {
     'usePostMessage',
     'tenant',
     'postMessageDataType',
-    'postMessageOrigin'
+    'postMessageOrigin',
+    'timeout'
   ]);
 
   handler = SilentAuthenticationHandler.create({

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -165,9 +165,9 @@ Popup.prototype.authorize = function(options, cb) {
 
   params = this.transactionManager.process(params);
 
-  delete params.domain;
-
-  url = this.client.buildAuthorizeUrl(params);
+  url = this.client.buildAuthorizeUrl(
+    objectHelper.blacklist(params, ['domain', 'tenant', 'popupOptions'])
+  );
 
   popup = this.getPopupHandler(options);
 

--- a/src/web-auth/web-message-handler.js
+++ b/src/web-auth/web-message-handler.js
@@ -32,20 +32,21 @@ WebMessageHandler.prototype.run = function(options, cb) {
   var _this = this;
   options.responseMode = 'web_message';
   options.prompt = 'none';
-  runWebMessageFlow(this.webAuth.client.buildAuthorizeUrl(options), options, function(
-    err,
-    eventData
-  ) {
-    var error = err;
-    if (!err && eventData.event.data.response.error) {
-      error = objectHelper.pick(eventData.event.data.response, ['error', 'error_description']);
+  runWebMessageFlow(
+    this.webAuth.client.buildAuthorizeUrl(objectHelper.blacklist(options, ['timeout'])),
+    options,
+    function(err, eventData) {
+      var error = err;
+      if (!err && eventData.event.data.response.error) {
+        error = objectHelper.pick(eventData.event.data.response, ['error', 'error_description']);
+      }
+      if (error) {
+        return cb(error);
+      }
+      var parsedHash = eventData.event.data.response;
+      _this.webAuth.validateAuthenticationResponse(options, parsedHash, cb);
     }
-    if (error) {
-      return cb(error);
-    }
-    var parsedHash = eventData.event.data.response;
-    _this.webAuth.validateAuthenticationResponse(options, parsedHash, cb);
-  });
+  );
 };
 
 module.exports = WebMessageHandler;

--- a/test/web-auth/extensibility.test.js
+++ b/test/web-auth/extensibility.test.js
@@ -98,7 +98,7 @@ describe('auth0.WebAuth extensibility', function() {
     it('should change the content of the params', function(done) {
       stub(PopupHandler.prototype, 'load', function(url, relayUrl, options, cb) {
         expect(url).to.be(
-          'https://test.auth0.com/authorize?client_id=...&response_type=code&tenant=test&owp=true&redirect_uri=http%3A%2F%2Fcustom-url.com&state=randomState'
+          'https://test.auth0.com/authorize?client_id=...&response_type=code&owp=true&redirect_uri=http%3A%2F%2Fcustom-url.com&state=randomState'
         );
         expect(relayUrl).to.be('https://test.auth0.com/relay.html');
         expect(options).to.eql({});


### PR DESCRIPTION
Using the `timeout` parameter with `renewAuth()` produces this warning in the console:
> Following parameters are not allowed on the `/authorize` endpoint: [timeout]

Likewise, using `tenant` and `popupOptions` with `popup.authorize()` produces this warning:
> Following parameters are not allowed on the `/authorize` endpoint: [tenant,popup_options]

These options needed to be blacklisted before the `/authorize` url is built.