### PR TITLE
Rename crossOriginVerification method

### DIFF
--- a/example/callback-cross-auth.html
+++ b/example/callback-cross-auth.html
@@ -1,16 +1,19 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <script src="/auth0.js"></script>
-    <script type="text/javascript">
-      var auth0 = new auth0.WebAuth({
-        domain: 'auth0-tests-auth0js.auth0.com',
-        redirectUri: 'https://localhost:3000/example',
-        clientID: '3GGMIEuBPZ28lb6NBDNARaEZisqFakAs',
-        responseType: 'token'
-      });
-      auth0.crossOriginAuthenticationCallback();
-    </script>
-  </head>
-  <body></body>
+
+<head>
+  <script src="/auth0.js"></script>
+  <script type="text/javascript">
+    var auth0 = new auth0.WebAuth({
+      domain: 'auth0-tests-auth0js.auth0.com',
+      redirectUri: 'https://localhost:3000/example',
+      clientID: '3GGMIEuBPZ28lb6NBDNARaEZisqFakAs',
+      responseType: 'token'
+    });
+    auth0.crossOriginVerification();
+  </script>
+</head>
+
+<body></body>
+
 </html>

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -575,8 +575,18 @@ WebAuth.prototype.passwordlessLogin = function(options, cb) {
  * Runs the callback code for the cross origin authentication call. This method is meant to be called by the cross origin authentication callback url.
  *
  * @method crossOriginAuthenticationCallback
+ * @deprecated Use {@link crossOriginVerification} instead.
  */
 WebAuth.prototype.crossOriginAuthenticationCallback = function() {
+  this.crossOriginVerification();
+};
+
+/**
+ * Runs the callback code for the cross origin authentication call. This method is meant to be called by the cross origin authentication callback url.
+ *
+ * @method crossOriginVerification
+ */
+WebAuth.prototype.crossOriginVerification = function() {
   this.crossOriginAuthentication.callback();
 };
 

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -1478,9 +1478,15 @@ describe('auth0.WebAuth', function() {
         return 'cb';
       });
     });
-    it('should call callback', function(done) {
+    it('should call callback with deprecated method `crossOriginAuthenticationCallback`', function(
+      done
+    ) {
       stub(CrossOriginAuthentication.prototype, 'callback', done);
       this.auth0.crossOriginAuthenticationCallback();
+    });
+    it('should call callback', function(done) {
+      stub(CrossOriginAuthentication.prototype, 'callback', done);
+      this.auth0.crossOriginVerification();
     });
   });
 


### PR DESCRIPTION
Better name for the cross origin verification callback.