### PR TITLE
Fix iframe bug sometimes occuring in chrome

### DIFF
--- a/src/helper/iframe-handler.js
+++ b/src/helper/iframe-handler.js
@@ -29,7 +29,6 @@ IframeHandler.prototype.init = function() {
 
   this.iframe = _window.document.createElement('iframe');
   this.iframe.style.display = 'none';
-  this.iframe.src = this.url;
 
   // Workaround to avoid using bind that does not work in IE8
   this.proxyEventListener = function(e) {
@@ -50,7 +49,9 @@ IframeHandler.prototype.init = function() {
   this.eventSourceObject.addEventListener(this.eventListenerType, this.proxyEventListener, false);
 
   _window.document.body.appendChild(this.iframe);
-
+  
+  this.iframe.src = this.url;
+  
   this.timeoutHandle = setTimeout(function() {
     _this.timeoutHandler();
   }, this.timeout);


### PR DESCRIPTION
In certain situations, chrome is not triggering fetch of iframe. This fix simply moves the iframe src update to after it is appended to the DOM.

See auth0 ticket: #31402