### PR TITLE
Setting last used username and connection when the hash is parsed

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -323,7 +323,7 @@
 
     $('.login-twitter').click(function (e) {
       e.preventDefault();
-      webAuth.authorize({ connection: 'twitter', scope: 'openid profile' });
+      webAuth.authorize({ connection: 'twitter' });
     });
 
     $('.login-github').click(function (e) {

--- a/example/index.html
+++ b/example/index.html
@@ -323,7 +323,7 @@
 
     $('.login-twitter').click(function (e) {
       e.preventDefault();
-      webAuth.authorize({ connection: 'twitter' });
+      webAuth.authorize({ connection: 'twitter', scope: 'openid profile' });
     });
 
     $('.login-github').click(function (e) {

--- a/src/helper/ssodata.js
+++ b/src/helper/ssodata.js
@@ -1,10 +1,18 @@
 var storage = require('./storage');
 
 module.exports = {
-  set: function(connection) {
-    storage.setItem('auth0.ssodata.connection', connection);
+  set: function(connection, username) {
+    var ssodata = {
+      lastUsedUsername: username,
+      lastUsedConnection: connection
+    };
+    storage.setItem('auth0.ssodata', JSON.stringify(ssodata));
   },
   get: function() {
-    return storage.getItem('auth0.ssodata.connection');
+    var ssodata = storage.getItem('auth0.ssodata');
+    if (!ssodata) {
+      return;
+    }
+    return JSON.parse(ssodata);
   }
 };

--- a/src/web-auth/cross-origin-authentication.js
+++ b/src/web-auth/cross-origin-authentication.js
@@ -2,7 +2,6 @@ var urljoin = require('url-join');
 
 var windowHelper = require('../helper/window');
 var objectHelper = require('../helper/object');
-var ssodata = require('../helper/ssodata');
 var RequestBuilder = require('../helper/request-builder');
 var WebMessageHandler = require('./web-message-handler');
 
@@ -73,15 +72,8 @@ CrossOriginAuthentication.prototype.login = function(options, cb) {
       };
       return cb(errorObject);
     }
-    ssodata.set(options.realm);
     var popupMode = options.popup === true;
-    options = objectHelper.blacklist(options, [
-      'username',
-      'password',
-      'credentialType',
-      'otp',
-      'popup'
-    ]);
+    options = objectHelper.blacklist(options, ['password', 'credentialType', 'otp', 'popup']);
     var authorizeOptions = objectHelper
       .merge(options)
       .with({ loginTicket: data.body.login_ticket });

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -191,7 +191,6 @@ WebAuth.prototype.validateAuthenticationResponse = function(options, parsedHash,
 
   var callback = function(err, payload) {
     if (err) {
-      console.log(err);
       return cb(err);
     }
     if (transaction && transaction.lastUsedConnection) {

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -6,7 +6,6 @@ var assert = require('../helper/assert');
 var responseHandler = require('../helper/response-handler');
 var PopupHandler = require('../helper/popup-handler');
 var objectHelper = require('../helper/object');
-var ssodata = require('../helper/ssodata');
 var Warn = require('../helper/warn');
 var TransactionManager = require('./transaction-manager');
 var CrossOriginAuthentication = require('./cross-origin-authentication');
@@ -140,9 +139,6 @@ Popup.prototype.authorize = function(options, cb) {
       responseType: { type: 'string', message: 'responseType option is required' }
     }
   );
-
-  var connection = params.realm || params.connection;
-  ssodata.set(connection);
 
   // the relay page should not be necesary as long it happens in the same domain
   // (a redirectUri shoul be provided). It is necesary when using OWP

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -163,7 +163,7 @@ Popup.prototype.authorize = function(options, cb) {
   }
 
   params = this.transactionManager.process(params);
-  params.scope = params.scope || 'openid profile email';
+  params.scope = params.scope || 'openid';
   delete params.domain;
 
   url = this.client.buildAuthorizeUrl(params);

--- a/src/web-auth/transaction-manager.js
+++ b/src/web-auth/transaction-manager.js
@@ -13,12 +13,16 @@ TransactionManager.prototype.process = function(options) {
   if (!options.responseType) {
     throw new Error('responseType is required');
   }
+  var lastUsedUsername = options.username || options.email;
+  var lastUsedConnection = options.realm || options.connection;
   var responseTypeIncludesIdToken = options.responseType.indexOf('id_token') !== -1;
 
   var transaction = this.generateTransaction(
     options.appState,
     options.state,
     options.nonce,
+    lastUsedUsername,
+    lastUsedConnection,
     responseTypeIncludesIdToken
   );
   if (!options.state) {
@@ -32,16 +36,24 @@ TransactionManager.prototype.process = function(options) {
   return options;
 };
 
-TransactionManager.prototype.generateTransaction = function(appState, state, nonce, generateNonce) {
+TransactionManager.prototype.generateTransaction = function(
+  appState,
+  state,
+  nonce,
+  lastUsedUsername,
+  lastUsedConnection,
+  generateNonce
+) {
   state = state || random.randomString(this.keyLength);
   nonce = nonce || (generateNonce ? random.randomString(this.keyLength) : null);
 
   storage.setItem(this.namespace + state, {
     nonce: nonce,
     appState: appState,
-    state: state
+    state: state,
+    lastUsedUsername: lastUsedUsername,
+    lastUsedConnection: lastUsedConnection
   });
-
   return {
     state: state,
     nonce: nonce

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -233,8 +233,11 @@ describe('auth0.authentication', function() {
         _sendTelemetry: false
       });
       stub(storage, 'getItem', function(key) {
-        expect(key).to.be('auth0.ssodata.connection');
-        return 'the-connection';
+        expect(key).to.be('auth0.ssodata');
+        return JSON.stringify({
+          lastUsedConnection: 'lastUsedConnection',
+          lastUsedUsername: 'lastUsedUsername'
+        });
       });
     });
     after(function() {
@@ -243,8 +246,8 @@ describe('auth0.authentication', function() {
     it('uses correct scope and responseType', function() {
       this.auth0.getSSOData();
       expect(this.webAuthSpy.checkSession.lastCall.args[0]).to.be.eql({
-        responseType: 'token id_token',
-        scope: 'openid profile email'
+        responseType: 'id_token',
+        scope: 'openid'
       });
     });
     it('returns sso:false if checkSession fails', function(done) {
@@ -272,7 +275,7 @@ describe('auth0.authentication', function() {
       this.auth0.getSSOData(function(err, result) {
         expect(err).to.be.eql({
           error: 'consent_required',
-          error_description: 'Consent required. When using `getSSOData`, the user has to be authenticated with the following the scope: `openid profile email`.'
+          error_description: 'Consent required. When using `getSSOData`, the user has to be authenticated with the following the scope: `openid`.'
         });
         expect(result).to.be.eql({ sso: false });
         done();
@@ -283,13 +286,13 @@ describe('auth0.authentication', function() {
         error_description: 'foobar'
       });
     });
-    it('returns ssoData object with email as lastUsedUsername', function(done) {
+    it('returns ssoData object with lastUsedConnection and lastUsedUsername', function(done) {
       this.auth0.getSSOData(function(err, result) {
         expect(err).to.be(null);
         expect(result).to.be.eql({
-          lastUsedConnection: { name: 'the-connection' },
+          lastUsedConnection: { name: 'lastUsedConnection' },
           lastUsedUserID: 'the-user-id',
-          lastUsedUsername: 'the@user.com',
+          lastUsedUsername: 'lastUsedUsername',
           lastUsedClientID: '...',
           sessionClients: ['...'],
           sso: true
@@ -298,27 +301,7 @@ describe('auth0.authentication', function() {
       });
 
       this.webAuthSpy.checkSession.lastCall.args[1](null, {
-        idTokenPayload: { sub: 'the-user-id', email: 'the@user.com', name: 'Will not be used' }
-      });
-    });
-    it('returns ssoData object with name as lastUsedUsername when email is not available', function(
-      done
-    ) {
-      this.auth0.getSSOData(function(err, result) {
-        expect(err).to.be(null);
-        expect(result).to.be.eql({
-          lastUsedConnection: { name: 'the-connection' },
-          lastUsedUserID: 'the-user-id',
-          lastUsedUsername: 'The User',
-          lastUsedClientID: '...',
-          sessionClients: ['...'],
-          sso: true
-        });
-        done();
-      });
-
-      this.webAuthSpy.checkSession.lastCall.args[1](null, {
-        idTokenPayload: { sub: 'the-user-id', name: 'The User' }
+        idTokenPayload: { sub: 'the-user-id' }
       });
     });
   });

--- a/test/helper/ssodata.test.js
+++ b/test/helper/ssodata.test.js
@@ -1,0 +1,48 @@
+var expect = require('expect.js');
+var stub = require('sinon').stub;
+
+var storage = require('../../src/helper/storage');
+var ssodata = require('../../src/helper/ssodata');
+
+describe('helpers', function() {
+  describe('ssodata', function() {
+    afterEach(function() {
+      if (storage.setItem.restore) {
+        storage.setItem.restore();
+      }
+      if (storage.getItem.restore) {
+        storage.getItem.restore();
+      }
+    });
+    describe('get', function() {
+      it('when there is data', function() {
+        var expectedObject = { foo: 'bar' };
+        stub(storage, 'getItem', function() {
+          return JSON.stringify(expectedObject);
+        });
+        var data = ssodata.get();
+        expect(data).to.be.eql(expectedObject);
+      });
+      it('when there is no data', function() {
+        stub(storage, 'getItem', function() {
+          return undefined;
+        });
+        var data = ssodata.get();
+        expect(data).to.be(undefined);
+      });
+    });
+    describe('set', function() {
+      it('sets ssodata', function(done) {
+        stub(storage, 'setItem', function(key, value) {
+          expect(key).to.be('auth0.ssodata');
+          expect(JSON.parse(value)).to.be.eql({
+            lastUsedUsername: 'username',
+            lastUsedConnection: 'connection'
+          });
+          done();
+        });
+        ssodata.set('connection', 'username');
+      });
+    });
+  });
+});

--- a/test/web-auth/cross-origin-authentication.test.js
+++ b/test/web-auth/cross-origin-authentication.test.js
@@ -110,6 +110,7 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
         anotherOption: 'foobar'
       });
       expect(this.webAuthSpy.authorize.getCall(0).args[0]).to.be.eql({
+        username: 'me@example.com',
         loginTicket: 'a_login_ticket',
         anotherOption: 'foobar'
       });
@@ -142,6 +143,7 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
       });
       stub(WebMessageHandler.prototype, 'run', function(options, callback) {
         expect(options).to.be.eql({
+          username: 'me@example.com',
           loginTicket: 'a_login_ticket',
           anotherOption: 'foobar'
         });
@@ -190,6 +192,7 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
         realm: 'a-connection'
       });
       expect(this.webAuthSpy.authorize.getCall(0).args[0]).to.be.eql({
+        username: 'me@example.com',
         loginTicket: 'a_login_ticket',
         realm: 'a-connection'
       });
@@ -226,6 +229,7 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
         credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp'
       });
       expect(this.webAuthSpy.authorize.getCall(0).args[0]).to.be.eql({
+        username: 'me@example.com',
         loginTicket: 'a_login_ticket',
         realm: 'email'
       });

--- a/test/web-auth/cross-origin-authentication.test.js
+++ b/test/web-auth/cross-origin-authentication.test.js
@@ -43,43 +43,6 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
         storage.setItem.restore();
       }
     });
-    it('should store sso data when co/authenticate call succeeds', function(done) {
-      stub(request, 'post', function(url) {
-        expect(url).to.be('https://me.auth0.com/co/authenticate');
-        return new RequestMock({
-          body: {
-            client_id: '...',
-            credential_type: 'http://auth0.com/oauth/grant-type/password-realm',
-            username: 'me@example.com',
-            password: '123456',
-            realm: 'the-connection'
-          },
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          cb: function(cb) {
-            cb(null, {
-              body: {
-                login_ticket: 'a_login_ticket',
-                co_verifier: 'co_verifier',
-                co_id: 'co_id'
-              }
-            });
-          }
-        });
-      });
-      stub(storage, 'setItem', function(key, ssoData) {
-        expect(key).to.be.equal('auth0.ssodata.connection');
-        expect(ssoData).to.be.eql('the-connection');
-        done();
-      });
-      this.co.login({
-        username: 'me@example.com',
-        password: '123456',
-        anotherOption: 'foobar',
-        realm: 'the-connection'
-      });
-    });
     it('should call /co/authenticate and redirect to /authorize with login_ticket', function() {
       stub(request, 'post', function(url) {
         expect(url).to.be('https://me.auth0.com/co/authenticate');

--- a/test/web-auth/popup.test.js
+++ b/test/web-auth/popup.test.js
@@ -87,10 +87,10 @@ describe('auth0.WebAuth.popup', function() {
       PopupHandler.prototype.load.restore();
     });
 
-    it('should default scope to openid profile email', function(done) {
+    it('should default scope to openid', function(done) {
       stub(PopupHandler.prototype, 'load', function(url) {
         expect(url).to.be(
-          'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&tenant=me&connection=the_connection&state=123&nonce=456&scope=openid%20profile%20email'
+          'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&tenant=me&connection=the_connection&state=123&nonce=456&scope=openid'
         );
         storage.setItem.restore();
         TransactionManager.prototype.process.restore();
@@ -106,18 +106,6 @@ describe('auth0.WebAuth.popup', function() {
         state: '123',
         nonce: '456'
       });
-    });
-
-    it('should set ssodata.connection', function(done) {
-      stub(PopupHandler.prototype, 'load', function() {});
-      stub(storage, 'setItem', function(key, connection) {
-        expect(key).to.be('auth0.ssodata.connection');
-        expect(connection).to.be('foobar');
-        storage.setItem.restore();
-        done();
-      });
-
-      this.auth0.popup.authorize({ connection: 'foobar' });
     });
 
     it('should open the popup a with the proper parameters', function(done) {

--- a/test/web-auth/transaction-manager.test.js
+++ b/test/web-auth/transaction-manager.test.js
@@ -13,10 +13,18 @@ context('TransactionManager', function() {
   });
   context('process', function() {
     beforeEach(function() {
-      stub(TransactionManager.prototype, 'generateTransaction', function(appState, state, nonce) {
+      stub(TransactionManager.prototype, 'generateTransaction', function(
+        appState,
+        state,
+        nonce,
+        lastUsedUsername,
+        lastUsedConnection
+      ) {
         return {
           state: state || 'randomState',
-          nonce: nonce || 'randomNonce'
+          nonce: nonce || 'randomNonce',
+          lastUsedUsername: lastUsedUsername,
+          lastUsedConnection: lastUsedConnection
         };
       });
     });
@@ -41,12 +49,16 @@ context('TransactionManager', function() {
         appState,
         state,
         nonce,
+        lastUsedUsername,
+        lastUsedConnection,
         generateNonce
       ) {
         expect(generateNonce).to.be(true);
         return {
           state: state || 'randomState',
-          nonce: nonce || 'randomNonce'
+          nonce: nonce || 'randomNonce',
+          lastUsedUsername: lastUsedUsername,
+          lastUsedConnection: lastUsedConnection
         };
       });
       expect(this.tm.process({ responseType: 'code id_token', state: 'some-state' })).to.be.eql({
@@ -77,36 +89,61 @@ context('TransactionManager', function() {
       storage.setItem.restore();
     });
     it('always stores random state', function() {
-      var result = this.tm.generateTransaction('appState', null, null, false);
+      var result = this.tm.generateTransaction('appState', null, null, null, null, false);
       expect(result).to.be.eql({ state: 'randomString', nonce: null });
       expect(storage.setItem.calledOnce).to.be(true);
       expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
       expect(storage.setItem.lastCall.args[1]).to.be.eql({
         nonce: null,
         appState: 'appState',
-        state: 'randomString'
+        state: 'randomString',
+        lastUsedConnection: null,
+        lastUsedUsername: null
       });
     });
     it('only stores random nonce when generateNonce is true', function() {
-      var result = this.tm.generateTransaction('appState', null, null, true);
+      var result = this.tm.generateTransaction('appState', null, null, null, null, true);
       expect(result).to.be.eql({ state: 'randomString', nonce: 'randomString' });
       expect(storage.setItem.calledOnce).to.be(true);
       expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
       expect(storage.setItem.lastCall.args[1]).to.be.eql({
         nonce: 'randomString',
         appState: 'appState',
-        state: 'randomString'
+        state: 'randomString',
+        lastUsedConnection: null,
+        lastUsedUsername: null
       });
     });
     it('uses nonce/state when provided', function() {
-      var result = this.tm.generateTransaction('appState', 'state', 'nonce');
+      var result = this.tm.generateTransaction('appState', 'state', 'nonce', null, null);
       expect(result).to.be.eql({ state: 'state', nonce: 'nonce' });
       expect(storage.setItem.calledOnce).to.be(true);
       expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
       expect(storage.setItem.lastCall.args[1]).to.be.eql({
         nonce: 'nonce',
         appState: 'appState',
-        state: 'state'
+        state: 'state',
+        lastUsedConnection: null,
+        lastUsedUsername: null
+      });
+    });
+    it('uses lastUsedUsername and lastUsedConnection when provided', function() {
+      var result = this.tm.generateTransaction(
+        'appState',
+        'state',
+        'nonce',
+        'lastUsedUsername',
+        'lastUsedConnection'
+      );
+      expect(result).to.be.eql({ state: 'state', nonce: 'nonce' });
+      expect(storage.setItem.calledOnce).to.be(true);
+      expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
+      expect(storage.setItem.lastCall.args[1]).to.be.eql({
+        nonce: 'nonce',
+        appState: 'appState',
+        state: 'state',
+        lastUsedUsername: 'lastUsedUsername',
+        lastUsedConnection: 'lastUsedConnection'
       });
     });
   });

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -347,7 +347,8 @@ describe('auth0.WebAuth', function() {
             domain: 'brucke.auth0.com',
             redirectUri: 'http://example.com/callback',
             clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
-            responseType: 'token id_token'
+            responseType: 'token id_token',
+            __disableExpirationCheck: true
           });
           TransactionManager.prototype.getStoredTransaction.restore();
           stub(TransactionManager.prototype, 'getStoredTransaction', function() {

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -656,6 +656,30 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
+
+      it('should return default error if it is not a validation error', function(done) {
+        var expectedError = { error: 'some_error' };
+        stub(WebAuth.prototype, 'validateToken', function(token, nonce, callback) {
+          return callback(expectedError);
+        });
+        var webAuth = new WebAuth({
+          domain: 'mdocs_2.auth0.com',
+          redirectUri: 'http://example.com/callback',
+          clientID: '0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup',
+          responseType: 'token'
+        });
+
+        var data = webAuth.parseHash(
+          {
+            hash: '#token_type=Bearer&id_token=0as98da09s8d_not_a_token'
+          },
+          function(err, data) {
+            expect(err).to.be.eql(expectedError);
+            WebAuth.prototype.validateToken.restore();
+            done();
+          }
+        );
+      });
     });
     context('with HS256 id_token', function() {
       beforeEach(function() {

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -5,6 +5,7 @@ var request = require('superagent');
 
 var storage = require('../../src/helper/storage');
 var windowHelper = require('../../src/helper/window');
+var ssodata = require('../../src/helper/ssodata');
 
 var RequestMock = require('../mock/request-mock');
 
@@ -262,9 +263,11 @@ describe('auth0.WebAuth', function() {
 
     beforeEach(function() {
       spy(TransactionManager.prototype, 'getStoredTransaction');
+      spy(ssodata, 'set');
     });
     afterEach(function() {
       TransactionManager.prototype.getStoredTransaction.restore();
+      ssodata.set.restore();
     });
 
     it('should parse a valid hash without id_token', function(done) {
@@ -299,43 +302,139 @@ describe('auth0.WebAuth', function() {
       ); // eslint-disable-line
     });
 
-    it('should return transaction.appState', function(done) {
-      var webAuth = new WebAuth({
-        domain: 'mdocs.auth0.com',
-        redirectUri: 'http://example.com/callback',
-        clientID: '0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup',
-        responseType: 'token'
-      });
-      TransactionManager.prototype.getStoredTransaction.restore();
-      stub(TransactionManager.prototype, 'getStoredTransaction', function() {
-        return {
-          nonce: 'asfd',
-          appState: 'the-app-state'
-        };
-      });
+    context('when there is a transaction', function() {
+      it('should return transaction.appState', function(done) {
+        var webAuth = new WebAuth({
+          domain: 'mdocs.auth0.com',
+          redirectUri: 'http://example.com/callback',
+          clientID: '0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup',
+          responseType: 'token'
+        });
+        TransactionManager.prototype.getStoredTransaction.restore();
+        stub(TransactionManager.prototype, 'getStoredTransaction', function() {
+          return {
+            nonce: 'asfd',
+            appState: 'the-app-state'
+          };
+        });
 
-      var data = webAuth.parseHash(
-        {
-          hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
-        },
-        function(err, data) {
-          expect(data).to.eql({
-            accessToken: 'VjubIMBmpgQ2W2',
-            idToken: null,
-            idTokenPayload: null,
-            appState: 'the-app-state',
-            refreshToken: 'kajshdgfkasdjhgfas',
-            state: null,
-            expiresIn: null,
-            tokenType: 'Bearer',
-            scope: null
+        var data = webAuth.parseHash(
+          {
+            hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+          },
+          function(err, data) {
+            expect(data).to.eql({
+              accessToken: 'VjubIMBmpgQ2W2',
+              idToken: null,
+              idTokenPayload: null,
+              appState: 'the-app-state',
+              refreshToken: 'kajshdgfkasdjhgfas',
+              state: null,
+              expiresIn: null,
+              tokenType: 'Bearer',
+              scope: null
+            });
+
+            expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
+
+            done();
+          }
+        ); // eslint-disable-line
+      });
+      context('when there is a transaction.lastUsedConnection', function() {
+        beforeEach(function() {
+          this.webAuth = new WebAuth({
+            domain: 'brucke.auth0.com',
+            redirectUri: 'http://example.com/callback',
+            clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
+            responseType: 'token id_token'
           });
+          TransactionManager.prototype.getStoredTransaction.restore();
+          stub(TransactionManager.prototype, 'getStoredTransaction', function() {
+            return {
+              lastUsedUsername: 'lastUsedUsername',
+              lastUsedConnection: 'lastUsedConnection'
+            };
+          });
+        });
+        it('sets ssodata with transaction.lastUsedUsername when there is no payload', function(
+          done
+        ) {
+          var data = this.webAuth.parseHash(
+            {
+              hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            },
+            function() {
+              expect(ssodata.set.calledOnce).to.be.ok();
+              expect(ssodata.set.firstCall.args).to.be.eql([
+                'lastUsedConnection',
+                'lastUsedUsername'
+              ]);
+              expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
 
-          expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
+              done();
+            }
+          ); // eslint-disable-line
+        });
+        it('sets ssodata with transaction.lastUsedUsername when there is a payload but no email or name', function(
+          done
+        ) {
+          var data = this.webAuth.parseHash(
+            {
+              hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTlmYmUxMTkzNzAzOWIyNjNhOGIyOWEyIiwiYXVkIjoiazV1M28yZmlBQThYd2VYRUVYNjA0S0N3Q2p6anRNVTYiLCJpYXQiOjE1MTE1NTE3ODMsImV4cCI6MTUxMTU4Nzc4MywiYXRfaGFzaCI6IkxGTDMxMlRXWDFGc1VNay00R2gxYWciLCJub25jZSI6IndFT2U3LUxDOG5sMUF1SHA3bnVjRl81TE1WUFZrTUJZIn0.fUJhEIPded3aO4iDrbniwGnAEZHX66Mjl7yCgIxSSCXlgrHlOATvbMi7XGQXNfPjGCivySoalMCS3MikvMGBFPFguChyJZ3myswT6US33hZSTycUYODvWSz8j7PeEpJrHdF4nAO4NvbC4JjogG92Xg2zx0KCZtoLK9datZiWEWHVUEVEXZCwceyowxQ4J5dqDzzLm9_V9qBsUYJtINqMM6jhHazk7OQUFZlE35R3l-Lps2oofqxZf11X7g0bgxo5ykSSr_KDvj9Hx0flk_u-eTTD2XVGMWe1TreJm1KMMuD01PicU1JGsJRA0hqE6Fd943OAEAIM6feMximK22rrHg',
+              nonce: 'wEOe7-LC8nl1AuHp7nucF_5LMVPVkMBY'
+            },
+            function() {
+              expect(ssodata.set.calledOnce).to.be.ok();
+              expect(ssodata.set.firstCall.args).to.be.eql([
+                'lastUsedConnection',
+                'lastUsedUsername'
+              ]);
+              expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
 
-          done();
-        }
-      ); // eslint-disable-line
+              done();
+            }
+          ); // eslint-disable-line
+        });
+        it('sets ssodata with payload.email when there is a payload and email', function(done) {
+          var data = this.webAuth.parseHash(
+            {
+              hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJlbWFpbCI6ImpvaG5mb29AZ21haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTlmYmUxMTkzNzAzOWIyNjNhOGIyOWEyIiwiYXVkIjoiazV1M28yZmlBQThYd2VYRUVYNjA0S0N3Q2p6anRNVTYiLCJpYXQiOjE1MTE1NTMyMTIsImV4cCI6MTUxMTU4OTIxMiwiYXRfaGFzaCI6IkRUQVlrUVpXSUNsRU5LdFVnbFpYT1EiLCJub25jZSI6InM4QzcyQ250YWczcHIwdVE3UHJzMHp1UVNrbWJ6LW9UIn0.K8OkMPcPNOe51gPHCpgV28q_QSQ6cwu4x3iuR0-oRbQI-VlaleenFuIWX-td4AGpO_kp5ZqTOURDDcW7ZKaNkrcEj0TX1rBTph2p9bR5WXgdNumtrjWTV4GFgVfGF0qiGnuP5KZkZjQaEJtwSWCf7WdQGv6A0-h54Mk5tYi1LgQkdIRhM5PU1wSe1sPv-02S_FA2WomP9XkRuZ8MyCMhlay1JMwFABFrUh6sAV3IF4iboi8yx73HQNliNSqEe9scn8M6ok-u8MKXYB-wcvELfLvqWTYGW0n2NpxZc5ktTXkmlWDgdbmd7yIaBr143LN7k0g4jP_R-pRl2gf00DdA_w',
+              nonce: 's8C72Cntag3pr0uQ7Prs0zuQSkmbz-oT'
+            },
+            function() {
+              expect(ssodata.set.calledOnce).to.be.ok();
+              expect(ssodata.set.firstCall.args).to.be.eql([
+                'lastUsedConnection',
+                'johnfoo@gmail.com'
+              ]);
+              expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
+
+              done();
+            }
+          ); // eslint-disable-line
+        });
+        it('sets ssodata with payload.name when there is a payload but no payload.email', function(
+          done
+        ) {
+          var data = this.webAuth.parseHash(
+            {
+              hash: '#access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJuaWNrbmFtZSI6ImpvaG5mb28iLCJuYW1lIjoiam9obmZvb0BnbWFpbC5jb20iLCJwaWN0dXJlIjoiaHR0cHM6Ly9zLmdyYXZhdGFyLmNvbS9hdmF0YXIvMzhmYTAwMjQyM2JkOGM5NDFjNmVkMDU4OGI2MGZmZWQ_cz00ODAmcj1wZyZkPWh0dHBzJTNBJTJGJTJGY2RuLmF1dGgwLmNvbSUyRmF2YXRhcnMlMkZqby5wbmciLCJ1cGRhdGVkX2F0IjoiMjAxNy0xMS0yNFQxOTo1NTozNC4xNjhaIiwiaXNzIjoiaHR0cHM6Ly9icnVja2UuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU5ZmJlMTE5MzcwMzliMjYzYThiMjlhMiIsImF1ZCI6Ims1dTNvMmZpQUE4WHdlWEVFWDYwNEtDd0Nqemp0TVU2IiwiaWF0IjoxNTExNTUzMzM1LCJleHAiOjE1MTE1ODkzMzUsImF0X2hhc2giOiJYWnhkdjFKSG10RjNNbjU2UmNYemlnIiwibm9uY2UiOiJVai1TRjF6UnR2RlpIZ2pfVkhjTTJicEFUS015ZElNRiJ9.OJOhUnNtU8IaVUkfUFSZd9YuGTjb0LptC6AQe0JXiKKBqJ5T5p0LqdkQCQgPOvi5PufoUe-6UUD_hPOw7B02rpZb02vTsbD3dCz6T7rVu8X7CFGvdBpnMNqjl5rh0bSm_6dDnzAIvheaEuQqULRBPlWQNUu2vnHu6PWjz9xIzaZakpB7YnRCjqy3PhM7t7oE-wCi8qUnrkcisRPj9GqKDKV4a5H7V4_MMWgCFQb8v5LDcuvgUvM-uOZot3LQI_kTuQXA1Xnvppqbv-Nc757RK-caWJedtlDV0sTgAuALOGx8kLWk9V1RndwpO86KTK-SQBqB-FnkEhsgR_YR_FhPJw',
+              nonce: 'Uj-SF1zRtvFZHgj_VHcM2bpATKMydIMF'
+            },
+            function() {
+              expect(ssodata.set.calledOnce).to.be.ok();
+              expect(ssodata.set.firstCall.args).to.be.eql([
+                'lastUsedConnection',
+                'johnfoo@gmail.com'
+              ]);
+              expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
+
+              done();
+            }
+          ); // eslint-disable-line
+        });
+      });
     });
 
     context('with RS256 id_token', function() {
@@ -351,15 +450,13 @@ describe('auth0.WebAuth', function() {
         var data = webAuth.parseHash(
           {
             nonce: 'asfd',
-            hash:
-              '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&scope=foo'
+            hash: '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&scope=foo'
           },
           function(err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               accessToken: 'VjubIMBmpgQ2W2',
-              idToken:
-                'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
+              idToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
               idTokenPayload: {
                 iss: 'https://wptest.auth0.com/',
                 sub: 'auth0|55d48c57d5b0ad0223c408d7',
@@ -396,8 +493,7 @@ describe('auth0.WebAuth', function() {
           expect(err).to.be(null);
           expect(data).to.eql({
             accessToken: 'asldkfjahsdlkfjhasd',
-            idToken:
-              'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
+            idToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
             idTokenPayload: {
               iss: 'https://wptest.auth0.com/',
               sub: 'auth0|55d48c57d5b0ad0223c408d7',
@@ -434,8 +530,7 @@ describe('auth0.WebAuth', function() {
 
         var data = webAuth.parseHash(
           {
-            hash:
-              '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.eql({
@@ -463,8 +558,7 @@ describe('auth0.WebAuth', function() {
 
         var data = webAuth.parseHash(
           {
-            hash:
-              '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.eql({
@@ -486,8 +580,7 @@ describe('auth0.WebAuth', function() {
 
         var data = webAuth.parseHash(
           {
-            hash:
-              '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.eql({
@@ -509,8 +602,7 @@ describe('auth0.WebAuth', function() {
 
         var data = webAuth.parseHash(
           {
-            hash:
-              '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.eql({
@@ -586,15 +678,13 @@ describe('auth0.WebAuth', function() {
 
         var data = this.webAuth.parseHash(
           {
-            hash:
-              '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.be(null);
             expect(data).to.be.eql({
               accessToken: 'VjubIMBmpgQ2W2',
-              idToken:
-                'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg',
+              idToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg',
               idTokenPayload: { from: 'userinfo' },
               appState: null,
               refreshToken: 'kajshdgfkasdjhgfas',
@@ -614,8 +704,7 @@ describe('auth0.WebAuth', function() {
 
         var data = this.webAuth.parseHash(
           {
-            hash:
-              '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+            hash: '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2F1dGgwLXRlc3RzLWxvY2suYXV0aDAuY29tLyIsImlhdCI6MTUwOTA0MDk4MiwiZXhwIjoxNTQwNTc2OTgyLCJhdWQiOiJpeGVPSEZoRDdOU1B4RVFLNkNGY3N3alVzYTVZa2NYUyIsInN1YiI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJHaXZlbk5hbWUiOiJKb2hubnkiLCJTdXJuYW1lIjoiUm9ja2V0IiwiRW1haWwiOiJqcm9ja2V0QGV4YW1wbGUuY29tIiwiUm9sZSI6WyJNYW5hZ2VyIiwiUHJvamVjdCBBZG1pbmlzdHJhdG9yIl19._JvcLjX308NtT16oegF2wFeOcdEYKM3DqX-V4POwIeg&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
           function(err, data) {
             expect(err).to.be.eql({
@@ -701,7 +790,7 @@ describe('auth0.WebAuth', function() {
         storage.removeItem.restore();
       }
     });
-    it('should default scope to openid profile email', function(done) {
+    it('should default scope to openid', function(done) {
       var webAuth = new WebAuth({
         domain: 'me.auth0.com',
         redirectUri: 'http://page.com/callback',
@@ -711,7 +800,7 @@ describe('auth0.WebAuth', function() {
       });
       stub(windowHelper, 'redirect', function(url) {
         expect(url).to.be(
-          'https://me.auth0.com/authorize?client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&connection=foobar&state=randomState&scope=openid%20profile%20email'
+          'https://me.auth0.com/authorize?client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&connection=foobar&state=randomState&scope=openid'
         );
         windowHelper.redirect.restore();
         done();
@@ -734,24 +823,6 @@ describe('auth0.WebAuth', function() {
       }).to.throwException(function(e) {
         expect(e.message).to.be('responseType option is required');
       });
-    });
-    it('should set ssodata.connection', function(done) {
-      stub(storage, 'setItem', function(key, connection) {
-        expect(key).to.be('auth0.ssodata.connection');
-        expect(connection).to.be('foobar');
-        done();
-      });
-      var webAuth = new WebAuth({
-        domain: 'me.auth0.com',
-        redirectUri: 'http://page.com/callback',
-        clientID: '...',
-        scope: 'openid name read:blog',
-        audience: 'urn:site:demo:blog',
-        responseType: 'token',
-        _sendTelemetry: false
-      });
-
-      webAuth.authorize({ connection: 'foobar' });
     });
   });
 
@@ -802,8 +873,7 @@ describe('auth0.WebAuth', function() {
         expect(err).to.be(null);
         expect(data).to.eql({
           accessToken: null,
-          idToken:
-            'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
+          idToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA',
           idTokenPayload: {
             iss: 'https://wptest.auth0.com/',
             sub: 'auth0|55d48c57d5b0ad0223c408d7',
@@ -1566,7 +1636,6 @@ describe('auth0.WebAuth', function() {
     });
     it('timeoutCallback calls callback with error response', function(done) {
       stub(IframeHandler.prototype, 'init', function() {
-        console.log('ca;llleleled');
         this.timeoutCallback();
       });
       this.auth0.checkSession({}, function(err, data) {


### PR DESCRIPTION
Instead of setting the connection when initiating the auth request and asking for the scope "openid profile email" when trying to use the `checkSession` method, we instead store everything locally when the hash is parsed. This has the benefit of not needing to ask more scopes than necessary when calling the `getSSOData` method. It also only sets the last used connection if the hash is successfully parsed and validated (if you have an id_token), which means we can guarantee that the auth request worked.