### PR TITLE
Support browsers that return undefined on window.origin

### DIFF
--- a/src/web-auth/silent-authentication-handler.js
+++ b/src/web-auth/silent-authentication-handler.js
@@ -11,8 +11,7 @@ function SilentAuthenticationHandler(options) {
   this.postMessageOrigin =
     options.postMessageOrigin ||
     windowHelper.getWindow().origin ||
-    windowHelper.getWindow().location.protocol + '//' + windowHelper.getWindow().location.hostname
-      + (windowHelper.getWindow().location.port ? windowHelper.getWindow().location.port : '');
+    windowHelper.getWindow().location.origin;
 }
 
 SilentAuthenticationHandler.create = function(options) {

--- a/src/web-auth/silent-authentication-handler.js
+++ b/src/web-auth/silent-authentication-handler.js
@@ -6,7 +6,13 @@ function SilentAuthenticationHandler(options) {
   this.timeout = options.timeout || 60 * 1000;
   this.handler = null;
   this.postMessageDataType = options.postMessageDataType || false;
-  this.postMessageOrigin = options.postMessageOrigin || windowHelper.getWindow().origin;
+
+  // prefer origin from options, fallback to origin from browser, and some browsers (for example MS Edge) don't support origin; fallback to construct origin manually
+  this.postMessageOrigin =
+    options.postMessageOrigin ||
+    windowHelper.getWindow().origin ||
+    windowHelper.getWindow().location.protocol + '//' + windowHelper.getWindow().location.hostname
+      + (windowHelper.getWindow().location.port ? windowHelper.getWindow().location.port : '');
 }
 
 SilentAuthenticationHandler.create = function(options) {

--- a/src/web-auth/silent-authentication-handler.js
+++ b/src/web-auth/silent-authentication-handler.js
@@ -10,8 +10,9 @@ function SilentAuthenticationHandler(options) {
   // prefer origin from options, fallback to origin from browser, and some browsers (for example MS Edge) don't support origin; fallback to construct origin manually
   this.postMessageOrigin =
     options.postMessageOrigin ||
-    windowHelper.getWindow().origin ||
-    windowHelper.getWindow().location.origin;
+    windowHelper.getWindow().location.origin ||
+    windowHelper.getWindow().location.protocol + '//' + windowHelper.getWindow().location.hostname
+      + (windowHelper.getWindow().location.port ? ':' + windowHelper.getWindow().location.port : '');
 }
 
 SilentAuthenticationHandler.create = function(options) {

--- a/test/web-auth/silent-authentication-handler.test.js
+++ b/test/web-auth/silent-authentication-handler.test.js
@@ -14,10 +14,14 @@ var iframeHandler = {};
 
 describe('handlers silent-authentication-handler', function() {
   context('with context', function() {
+    beforeEach(function() {
+      global.window = { location: { origin: 'unit-test-origin' } }
+    });
     afterEach(function() {
       if (IframeHandler.prototype.init.restore) {
         IframeHandler.prototype.init.restore();
       }
+      delete global.window;
     });
     it('should return correct value for usePostMessage=false', function(done) {
       stub(IframeHandler.prototype, 'init', function() {
@@ -253,6 +257,42 @@ describe('handlers silent-authentication-handler', function() {
       var validator = sah.getEventValidator();
 
       expect(validator.isValid({ event: { type: 'load' } })).to.be(true);
+    });
+  });
+
+  context('constructor', function() {
+    it('sets postMessageOrigin from parameter', function() {
+      var expectedOrigin = 'unit-test-post-message-origin';
+      var param = { postMessageOrigin: expectedOrigin };
+
+      var sah = new SilentAuthenticationHandler(param);
+
+      expect(sah.postMessageOrigin).to.be(expectedOrigin);
+    });
+
+    it('sets postMessageOrigin from window', function() {
+      var expectedOrigin = 'unit-test-location-origin';
+      global.window = { location: { origin: expectedOrigin } };
+
+      var sah = new SilentAuthenticationHandler({});
+
+      expect(sah.postMessageOrigin).to.be(expectedOrigin);
+    });
+
+    it('sets postMessageOrigin from fallback (with port)', function() {
+      global.window = { location: { protocol: 'https:', hostname: 'unit-test', port: 1234 } };
+
+      var sah = new SilentAuthenticationHandler({});
+
+      expect(sah.postMessageOrigin).to.be('https://unit-test:1234');
+    });
+
+    it('sets postMessageOrigin from fallback (without port)', function() {
+      global.window = { location: { protocol: 'https:', hostname: 'unit-test' } };
+
+      var sah = new SilentAuthenticationHandler({});
+
+      expect(sah.postMessageOrigin).to.be('https://unit-test');
     });
   });
 });

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -76,6 +76,7 @@ describe('auth0.WebAuth', function() {
           appState: null
         });
       };
+      global.window.location = {};
       storage.reload();
     });
 
@@ -663,6 +664,7 @@ describe('auth0.WebAuth', function() {
   context('renewAuth', function() {
     beforeEach(function() {
       global.window = {};
+      global.window.origin = 'unit-test-origin';
       global.window.removeEventListener = function() {};
     });
     afterEach(function() {
@@ -751,6 +753,7 @@ describe('auth0.WebAuth', function() {
     beforeEach(function() {
       global.window = {};
       global.window.document = {};
+      global.window.origin = 'unit-test-origin';
     });
 
     afterEach(function() {
@@ -815,6 +818,12 @@ describe('auth0.WebAuth', function() {
       });
     });
     describe('should return the access_token', function() {
+      beforeEach(function() {
+        global.window = { origin: 'unit-test-origin' };
+      });
+      afterEach(function() {
+        delete global.window;
+      });
       it('when login returns an object', function(done) {
         stub(SilentAuthenticationHandler.prototype, 'login', function(usePostMessage, cb) {
           cb(null, { accessToken: '123' });


### PR DESCRIPTION
Some browsers don't support window.origin. See [compatibility chart on MDN](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/origin#Browser_compatibility).

This pull requests constructs window.origin if it's not provided.