### PR TITLE
Adding usernamepassword/login support for hosted login page

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -270,7 +270,7 @@
 
     $('.universal-login').click(function (e) {
       e.preventDefault();
-      webAuth._hostedPages.login({
+      webAuth._universalLogin.login({
         connection: 'acme',
         username: $('.login-username').val(),
         password: $('.login-password').val()

--- a/example/index.html
+++ b/example/index.html
@@ -117,17 +117,10 @@
     <div class="col-xs-6">
 
       <div>
-        <h2>Login with database connection:</h2>
+        <h2>Login with username and password:</h2>
         <input class="login-username" value="johnfoo@gmail.com" />
         <input class="login-password" value="1234" />
         <input type="button" class="login-db" value="login" />
-      </div>
-
-      <div>
-        <h2>Login with database connection (from universal login):</h2>
-        <input class="login-username" value="johnfoo@gmail.com" />
-        <input class="login-password" value="1234" />
-        <input type="button" class="universal-login" value="login" />
       </div>
 
       <div>
@@ -176,13 +169,6 @@
       <div>
         <h2>Renew authentication:</h2>
         <input type="button" class="renew-auth" value="Renew" />
-      </div>
-
-      <div>
-        <h2>Login with Cross Origin Authentication flow:</h2>
-        <input class="cross-origin-auth-username" value="johnfoo@gmail.com" />
-        <input class="cross-origin-auth-password" value="1234" />
-        <input type="button" class="cross-origin-auth" value="Login" />
       </div>
       <div>
         <h2>Check if you have an active session:</h2>
@@ -261,17 +247,8 @@
 
     $('.login-db').click(function (e) {
       e.preventDefault();
-      webAuth.redirect.loginWithCredentials({
-        connection: 'acme',
-        username: $('.login-username').val(),
-        password: $('.login-password').val()
-      }, htmlConsole.dumpCallback.bind(htmlConsole));
-    });
-
-    $('.universal-login').click(function (e) {
-      e.preventDefault();
-      webAuth._universalLogin.login({
-        connection: 'acme',
+      webAuth.login({
+        realm: 'acme',
         username: $('.login-username').val(),
         password: $('.login-password').val()
       }, htmlConsole.dumpCallback.bind(htmlConsole));
@@ -379,15 +356,6 @@
       },
         htmlConsole.dumpCallback.bind(htmlConsole)
       );
-    });
-    $('.cross-origin-auth').click(function (e) {
-      e.preventDefault();
-      webAuth.login({
-        username: $('.cross-origin-auth-username').val(),
-        password: $('.cross-origin-auth-password').val(),
-        redirectURI: 'https://localhost:3000/example/',
-        realm: 'acme'
-      }, htmlConsole.dumpCallback.bind(htmlConsole));
     });
     $('.web-message-check-session').click(function (e) {
       e.preventDefault();

--- a/example/index.html
+++ b/example/index.html
@@ -124,6 +124,13 @@
       </div>
 
       <div>
+        <h2>Login with database connection (from universal login):</h2>
+        <input class="login-username" value="johnfoo@gmail.com" />
+        <input class="login-password" value="1234" />
+        <input type="button" class="universal-login" value="login" />
+      </div>
+
+      <div>
         <h2>Login with passwordless connection:</h2>
         <div>
           <input class="passwordless-login-username" value="" />
@@ -255,6 +262,15 @@
     $('.login-db').click(function (e) {
       e.preventDefault();
       webAuth.redirect.loginWithCredentials({
+        connection: 'acme',
+        username: $('.login-username').val(),
+        password: $('.login-password').val()
+      }, htmlConsole.dumpCallback.bind(htmlConsole));
+    });
+
+    $('.universal-login').click(function (e) {
+      e.preventDefault();
+      webAuth._hostedPages.login({
         connection: 'acme',
         username: $('.login-username').val(),
         password: $('.login-password').val()

--- a/src/web-auth/hosted-pages.js
+++ b/src/web-auth/hosted-pages.js
@@ -1,0 +1,98 @@
+var UsernamePassword = require('./username-password');
+var objectHelper = require('../helper/object');
+var windowHelper = require('../helper/window');
+var Warn = require('../helper/warn');
+var assert = require('../helper/assert');
+
+function HostedPages(client, options) {
+  this.baseOptions = options;
+  this.client = client;
+
+  this.warn = new Warn({
+    disableWarnings: !!options._disableDeprecationWarnings
+  });
+}
+
+/**
+ * @callback credentialsCallback
+ * @param {Error} [err] error returned by Auth0 with the reason of the Auth failure
+ * @param {Object} [result] result of the AuthN request
+ * @param {String} result.accessToken token that can be used with {@link userinfo}
+ * @param {String} [result.idToken] token that identifies the user
+ * @param {String} [result.refreshToken] token that can be used to get new access tokens from Auth0. Note that not all clients can request them or the resource server might not allow them.
+ */
+
+/**
+ * Performs authentication with username/email and password with a database connection
+ *
+ * This method is not compatible with API Auth so if you need to fetch API tokens with audience
+ * you should use {@link authorize} or {@link login}.
+ *
+ * @method loginWithCredentials
+ * @param {Object} options
+ * @param {String} [options.redirectUri] url that the Auth0 will redirect after Auth with the Authorization Response
+ * @param {String} [options.responseType] type of the response used. It can be any of the values `code` and `token`
+ * @param {String} [options.responseMode] how the AuthN response is encoded and redirected back to the client. Supported values are `query` and `fragment`
+ * @param {String} [options.scope] scopes to be requested during AuthN. e.g. `openid email`
+ * @param {credentialsCallback} cb
+ */
+HostedPages.prototype.login = function(options, cb) {
+  if (windowHelper.getWindow().location.host !== this.baseOptions.domain) {
+    throw new Error('This method is meant to be used only inside the Universal Login Page.');
+  }
+  var usernamePassword;
+
+  var params = objectHelper
+    .merge(this.baseOptions, [
+      'clientID',
+      'redirectUri',
+      'tenant',
+      'responseType',
+      'responseMode',
+      'scope',
+      'audience',
+      '_csrf',
+      'state',
+      '_intstate',
+      'nonce'
+    ])
+    .with(options);
+
+  assert.check(
+    params,
+    { type: 'object', message: 'options parameter is not valid' },
+    {
+      responseType: { type: 'string', message: 'responseType option is required' }
+    }
+  );
+
+  usernamePassword = new UsernamePassword(this.baseOptions);
+  return usernamePassword.login(params, function(err, data) {
+    if (err) {
+      return cb(err);
+    }
+    return usernamePassword.callback(data);
+  });
+};
+
+/**
+ * Signs up a new user and automatically logs the user in after the signup.
+ *
+ * @method signupAndLogin
+ * @param {Object} options
+ * @param {String} options.email user email address
+ * @param {String} options.password user password
+ * @param {String} options.connection name of the connection where the user will be created
+ * @param {credentialsCallback} cb
+ */
+HostedPages.prototype.signupAndLogin = function(options, cb) {
+  var _this = this;
+  return _this.client.client.dbConnection.signup(options, function(err) {
+    if (err) {
+      return cb(err);
+    }
+    return _this.login(options, cb);
+  });
+};
+
+module.exports = HostedPages;

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -14,6 +14,7 @@ var Popup = require('./popup');
 var SilentAuthenticationHandler = require('./silent-authentication-handler');
 var CrossOriginAuthentication = require('./cross-origin-authentication');
 var WebMessageHandler = require('./web-message-handler');
+var HostedPages = require('./hosted-pages');
 
 /**
  * Handles all the browser's AuthN/AuthZ flows
@@ -107,6 +108,7 @@ function WebAuth(options) {
   this.popup = new Popup(this, this.baseOptions);
   this.crossOriginAuthentication = new CrossOriginAuthentication(this, this.baseOptions);
   this.webMessageHandler = new WebMessageHandler(this);
+  this._hostedPages = new HostedPages(this, this.baseOptions);
 }
 
 /**

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -108,7 +108,7 @@ function WebAuth(options) {
   this.popup = new Popup(this, this.baseOptions);
   this.crossOriginAuthentication = new CrossOriginAuthentication(this, this.baseOptions);
   this.webMessageHandler = new WebMessageHandler(this);
-  this._hostedPages = new HostedPages(this, this.baseOptions);
+  this._universalLogin = new HostedPages(this, this.baseOptions);
 }
 
 /**

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -562,7 +562,14 @@ WebAuth.prototype.signupAndAuthorize = function(options, cb) {
  * @param {crossOriginLoginCallback} cb Callback function called only when an authentication error, like invalid username or password, occurs. For other types of errors, there will be a redirect to the `redirectUri`.
  */
 WebAuth.prototype.login = function(options, cb) {
-  this.crossOriginAuthentication.login(options, cb);
+  var isHostedLoginPage = windowHelper.getWindow().location.host === this.baseOptions.domain;
+  if (isHostedLoginPage) {
+    options.connection = options.realm;
+    delete options.realm;
+    this._universalLogin.login(options, cb);
+  } else {
+    this.crossOriginAuthentication.login(options, cb);
+  }
 };
 
 /**

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -585,16 +585,21 @@ WebAuth.prototype.login = function(options, cb) {
  * @param {crossOriginLoginCallback} cb Callback function called only when an authentication error, like invalid username or password, occurs. For other types of errors, there will be a redirect to the `redirectUri`.
  */
 WebAuth.prototype.passwordlessLogin = function(options, cb) {
-  var loginOptions = objectHelper.extend(
-    {
-      credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
-      realm: options.connection,
-      username: options.email || options.phoneNumber,
-      otp: options.verificationCode
-    },
-    objectHelper.blacklist(options, ['connection', 'email', 'phoneNumber', 'verificationCode'])
-  );
-  this.crossOriginAuthentication.login(loginOptions, cb);
+  var isHostedLoginPage = windowHelper.getWindow().location.host === this.baseOptions.domain;
+  if (isHostedLoginPage) {
+    this.passwordlessVerify(options, cb);
+  } else {
+    var crossOriginOptions = objectHelper.extend(
+      {
+        credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+        realm: options.connection,
+        username: options.email || options.phoneNumber,
+        otp: options.verificationCode
+      },
+      objectHelper.blacklist(options, ['connection', 'email', 'phoneNumber', 'verificationCode'])
+    );
+    this.crossOriginAuthentication.login(crossOriginOptions, cb);
+  }
 };
 
 /**

--- a/src/web-auth/username-password.js
+++ b/src/web-auth/username-password.js
@@ -1,0 +1,55 @@
+var urljoin = require('url-join');
+
+var objectHelper = require('../helper/object');
+var RequestBuilder = require('../helper/request-builder');
+var responseHandler = require('../helper/response-handler');
+var windowHelper = require('../helper/window');
+var TransactionManager = require('./transaction-manager');
+
+function UsernamePassword(options) {
+  this.baseOptions = options;
+  this.request = new RequestBuilder(options);
+  this.transactionManager = new TransactionManager(this.baseOptions.transaction);
+}
+
+UsernamePassword.prototype.login = function(options, cb) {
+  var url;
+  var body;
+
+  url = urljoin(this.baseOptions.rootUrl, 'usernamepassword', 'login');
+
+  options.username = options.username || options.email; // eslint-disable-line
+
+  options = objectHelper.blacklist(options, ['email']); // eslint-disable-line
+
+  body = objectHelper
+    .merge(this.baseOptions, [
+      'clientID',
+      'redirectUri',
+      'tenant',
+      'responseType',
+      'responseMode',
+      'scope',
+      'audience'
+    ])
+    .with(options);
+  body = this.transactionManager.process(body);
+
+  body = objectHelper.toSnakeCase(body, ['auth0Client']);
+
+  return this.request.post(url).send(body).end(responseHandler(cb));
+};
+
+UsernamePassword.prototype.callback = function(formHtml) {
+  var div;
+  var form;
+  var _document = windowHelper.getDocument();
+
+  div = _document.createElement('div');
+  div.innerHTML = formHtml;
+  form = _document.body.appendChild(div).children[0];
+
+  form.submit();
+};
+
+module.exports = UsernamePassword;

--- a/test/web-auth/hosted-pages.test.js
+++ b/test/web-auth/hosted-pages.test.js
@@ -11,7 +11,7 @@ var RequestBuilder = require('../../src/helper/request-builder');
 
 var telemetryInfo = new RequestBuilder({}).getTelemetryData();
 
-describe('auth0.WebAuth._hostedPages', function() {
+describe('auth0.WebAuth._universalLogin', function() {
   beforeEach(function() {
     stub(TransactionManager.prototype, 'process', function(params) {
       return params;
@@ -55,7 +55,7 @@ describe('auth0.WebAuth._hostedPages', function() {
       var auth0 = new WebAuth(configuration);
 
       expect(function() {
-        auth0._hostedPages.login({
+        auth0._universalLogin.login({
           connection: 'tests',
           email: 'me@example.com',
           password: '1234',
@@ -120,7 +120,7 @@ describe('auth0.WebAuth._hostedPages', function() {
 
       var auth0 = new WebAuth(configuration);
 
-      auth0._hostedPages.login(
+      auth0._universalLogin.login(
         {
           connection: 'tests',
           username: 'me@example.com',
@@ -145,7 +145,7 @@ describe('auth0.WebAuth._hostedPages', function() {
         responseType: 'id_token'
       });
 
-      auth0._hostedPages.login({
+      auth0._universalLogin.login({
         connection: 'tests',
         username: 'me@example.com',
         password: '1234',
@@ -189,7 +189,7 @@ describe('auth0.WebAuth._hostedPages', function() {
 
       var auth0 = new WebAuth(configuration);
 
-      auth0._hostedPages.login(
+      auth0._universalLogin.login(
         {
           connection: 'tests',
           email: 'me@example.com',
@@ -300,7 +300,7 @@ describe('auth0.WebAuth._hostedPages', function() {
         throw new Error('Invalid URL');
       });
 
-      this.auth0._hostedPages.signupAndLogin(
+      this.auth0._universalLogin.signupAndLogin(
         {
           connection: 'the_connection',
           email: 'me@example.com',
@@ -358,7 +358,7 @@ describe('auth0.WebAuth._hostedPages', function() {
         });
       });
 
-      this.auth0._hostedPages.signupAndLogin(
+      this.auth0._universalLogin.signupAndLogin(
         {
           connection: 'the_connection',
           email: 'me@example.com',

--- a/test/web-auth/hosted-pages.test.js
+++ b/test/web-auth/hosted-pages.test.js
@@ -1,0 +1,389 @@
+var expect = require('expect.js');
+var stub = require('sinon').stub;
+var request = require('superagent');
+
+var RequestMock = require('../mock/request-mock');
+var UsernamePassword = require('../../src/web-auth/username-password');
+var windowHelper = require('../../src/helper/window');
+var WebAuth = require('../../src/web-auth');
+var TransactionManager = require('../../src/web-auth/transaction-manager');
+var RequestBuilder = require('../../src/helper/request-builder');
+
+var telemetryInfo = new RequestBuilder({}).getTelemetryData();
+
+describe('auth0.WebAuth._hostedPages', function() {
+  beforeEach(function() {
+    stub(TransactionManager.prototype, 'process', function(params) {
+      return params;
+    });
+  });
+  afterEach(function() {
+    TransactionManager.prototype.process.restore();
+  });
+  context('login', function() {
+    beforeEach(function() {
+      stub(windowHelper, 'getWindow', function() {
+        return {
+          location: {
+            host: 'me.auth0.com'
+          },
+          crypto: {
+            getRandomValues: function() {
+              return [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+            }
+          }
+        };
+      });
+    });
+    afterEach(function() {
+      windowHelper.getWindow.restore();
+      if (request.post.restore) {
+        request.post.restore();
+      }
+      if (windowHelper.getDocument.restore) {
+        windowHelper.getDocument.restore();
+      }
+    });
+    it('should throw an error if window.location.host !== domain', function() {
+      var configuration = {
+        domain: 'other-domain.auth0.com',
+        redirectUri: 'https://localhost:3000/example/',
+        clientID: '0HP71GSd6PuoRY',
+        responseType: 'token'
+      };
+
+      var auth0 = new WebAuth(configuration);
+
+      expect(function() {
+        auth0._hostedPages.login({
+          connection: 'tests',
+          email: 'me@example.com',
+          password: '1234',
+          scope: 'openid'
+        });
+      }).throwError('This method is meant to be used only inside the Universal Login Page.');
+    });
+
+    it('should authenticate the user, render the callback form and submit it', function(done) {
+      stub(request, 'post', function(url) {
+        expect(url).to.be('https://me.auth0.com/usernamepassword/login');
+        return new RequestMock({
+          body: {
+            client_id: '0HP71GSd6PuoRY',
+            connection: 'tests',
+            password: '1234',
+            redirect_uri: 'https://localhost:3000/example/',
+            response_type: 'id_token',
+            scope: 'openid',
+            tenant: 'me',
+            username: 'me@example.com'
+          },
+          headers: {
+            'Content-Type': 'application/json',
+            'Auth0-Client': telemetryInfo
+          },
+          cb: function(cb) {
+            cb(null, {
+              text: 'the_form_html',
+              type: 'text/html'
+            });
+          }
+        });
+      });
+
+      stub(windowHelper, 'getDocument', function() {
+        return {
+          createElement: function() {
+            return {};
+          },
+          body: {
+            appendChild: function(element) {
+              expect(element.innerHTML).to.eql('the_form_html');
+              return {
+                children: [
+                  {
+                    submit: done
+                  }
+                ]
+              };
+            }
+          }
+        };
+      });
+
+      var configuration = {
+        domain: 'me.auth0.com',
+        redirectUri: 'https://localhost:3000/example/',
+        clientID: '0HP71GSd6PuoRY',
+        responseType: 'id_token'
+      };
+
+      var auth0 = new WebAuth(configuration);
+
+      auth0._hostedPages.login(
+        {
+          connection: 'tests',
+          username: 'me@example.com',
+          password: '1234',
+          scope: 'openid'
+        },
+        function(err) {
+          console.log(err);
+        }
+      );
+    });
+    it('should use transactionManager.process', function(done) {
+      stub(request, 'post', function() {
+        expect(TransactionManager.prototype.process.calledOnce).to.be(true);
+        done();
+      });
+
+      var auth0 = new WebAuth({
+        domain: 'me.auth0.com',
+        redirectUri: 'https://localhost:3000/example/',
+        clientID: '0HP71GSd6PuoRY',
+        responseType: 'id_token'
+      });
+
+      auth0._hostedPages.login({
+        connection: 'tests',
+        username: 'me@example.com',
+        password: '1234',
+        scope: 'openid'
+      });
+    });
+    it('should propagate the error', function(done) {
+      stub(request, 'post', function(url) {
+        expect(url).to.be('https://me.auth0.com/usernamepassword/login');
+        return new RequestMock({
+          body: {
+            client_id: '0HP71GSd6PuoRY',
+            connection: 'tests',
+            password: '1234',
+            redirect_uri: 'https://localhost:3000/example/',
+            response_type: 'token',
+            scope: 'openid',
+            tenant: 'me',
+            username: 'me@example.com'
+          },
+          headers: {
+            'Content-Type': 'application/json',
+            'Auth0-Client': telemetryInfo
+          },
+          cb: function(cb) {
+            cb({
+              name: 'ValidationError',
+              code: 'invalid_user_password',
+              description: 'Wrong email or password.'
+            });
+          }
+        });
+      });
+
+      var configuration = {
+        domain: 'me.auth0.com',
+        redirectUri: 'https://localhost:3000/example/',
+        clientID: '0HP71GSd6PuoRY',
+        responseType: 'token'
+      };
+
+      var auth0 = new WebAuth(configuration);
+
+      auth0._hostedPages.login(
+        {
+          connection: 'tests',
+          email: 'me@example.com',
+          password: '1234',
+          scope: 'openid'
+        },
+        function(err) {
+          expect(err).to.eql({
+            original: {
+              name: 'ValidationError',
+              code: 'invalid_user_password',
+              description: 'Wrong email or password.'
+            },
+            name: 'ValidationError',
+            code: 'invalid_user_password',
+            description: 'Wrong email or password.'
+          });
+          done();
+        }
+      );
+    });
+  });
+
+  context('signup and login', function() {
+    before(function() {
+      this.auth0 = new WebAuth({
+        domain: 'me.auth0.com',
+        clientID: '...',
+        redirectUri: 'http://page.com/callback',
+        responseType: 'token',
+        _sendTelemetry: false
+      });
+      stub(windowHelper, 'getWindow', function() {
+        return {
+          location: {
+            host: 'me.auth0.com'
+          },
+          crypto: {
+            getRandomValues: function() {
+              return [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+            }
+          }
+        };
+      });
+    });
+
+    afterEach(function() {
+      request.post.restore();
+    });
+
+    after(function() {
+      windowHelper.getWindow.restore();
+    });
+
+    it('should call db-connection signup with all the options', function(done) {
+      stub(request, 'post', function(url) {
+        if (url === 'https://me.auth0.com/usernamepassword/login') {
+          return new RequestMock({
+            body: {
+              client_id: '...',
+              connection: 'the_connection',
+              password: '123456',
+              redirect_uri: 'http://page.com/callback',
+              response_type: 'token',
+              scope: 'openid',
+              tenant: 'me',
+              username: 'me@example.com'
+            },
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            cb: function(cb) {
+              cb({
+                response: {
+                  body: {
+                    name: 'ValidationError',
+                    code: 'invalid_user_password',
+                    description: 'Wrong email or password.'
+                  },
+                  statusCode: 400
+                }
+              });
+            }
+          });
+        } else if (url === 'https://me.auth0.com/dbconnections/signup') {
+          return new RequestMock({
+            body: {
+              client_id: '...',
+              connection: 'the_connection',
+              email: 'me@example.com',
+              password: '123456'
+            },
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            cb: function(cb) {
+              cb(null, {
+                body: {
+                  _id: '...',
+                  email_verified: false,
+                  email: 'me@example.com'
+                }
+              });
+            }
+          });
+        }
+
+        throw new Error('Invalid URL');
+      });
+
+      this.auth0._hostedPages.signupAndLogin(
+        {
+          connection: 'the_connection',
+          email: 'me@example.com',
+          password: '123456',
+          scope: 'openid'
+        },
+        function(err, data) {
+          expect(data).to.be(undefined);
+          expect(err).to.eql({
+            original: {
+              response: {
+                body: {
+                  name: 'ValidationError',
+                  code: 'invalid_user_password',
+                  description: 'Wrong email or password.'
+                },
+                statusCode: 400
+              }
+            },
+            name: 'ValidationError',
+            code: 'invalid_user_password',
+            description: 'Wrong email or password.',
+            statusCode: 400
+          });
+          done();
+        }
+      );
+    });
+
+    it('should propagate signup errors', function(done) {
+      stub(request, 'post', function(url) {
+        expect(url).to.be('https://me.auth0.com/dbconnections/signup');
+
+        return new RequestMock({
+          body: {
+            client_id: '...',
+            connection: 'the_connection',
+            email: 'me@example.com',
+            password: '123456'
+          },
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          cb: function(cb) {
+            cb({
+              response: {
+                statusCode: 400,
+                body: {
+                  code: 'user_exists',
+                  description: 'The user already exists.'
+                }
+              }
+            });
+          }
+        });
+      });
+
+      this.auth0._hostedPages.signupAndLogin(
+        {
+          connection: 'the_connection',
+          email: 'me@example.com',
+          password: '123456',
+          scope: 'openid'
+        },
+        function(err, data) {
+          expect(data).to.be(undefined);
+          expect(err).to.eql({
+            original: {
+              response: {
+                statusCode: 400,
+                body: {
+                  code: 'user_exists',
+                  description: 'The user already exists.'
+                }
+              }
+            },
+            code: 'user_exists',
+            description: 'The user already exists.',
+            statusCode: 400
+          });
+          done();
+        }
+      );
+    });
+  });
+});

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -1338,7 +1338,7 @@ describe('auth0.WebAuth', function() {
         );
       });
     });
-    context.only('when inside of the universal login page', function() {
+    context('when inside of the universal login page', function() {
       beforeEach(function() {
         stub(windowHelper, 'getWindow', function() {
           return {

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -1260,7 +1260,7 @@ describe('auth0.WebAuth', function() {
   });
 
   context('passwordlessLogin', function() {
-    before(function() {
+    beforeEach(function() {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -1269,62 +1269,135 @@ describe('auth0.WebAuth', function() {
         _sendTelemetry: false
       });
     });
-
-    afterEach(function() {
-      if (CrossOriginAuthentication.prototype.login.restore) {
-        CrossOriginAuthentication.prototype.login.restore();
-      }
-      if (CrossOriginAuthentication.prototype.callback.restore) {
-        CrossOriginAuthentication.prototype.callback.restore();
-      }
-    });
-    it('should call `crossOriginAuthentication.login` with phoneNumber', function(done) {
-      var expectedOptions = {
-        credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
-        realm: 'sms',
-        username: '+55165134',
-        otp: '123456'
-      };
-      stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
-        expect(options).to.be.eql(expectedOptions);
-        expect(cb()).to.be('cb');
-        done();
+    context('when outside of the universal login page', function() {
+      beforeEach(function() {
+        stub(windowHelper, 'getWindow', function() {
+          return {
+            location: {
+              host: 'other-domain.auth0.com'
+            }
+          };
+        });
       });
 
-      this.auth0.passwordlessLogin(
-        {
+      afterEach(function() {
+        windowHelper.getWindow.restore();
+        if (CrossOriginAuthentication.prototype.login.restore) {
+          CrossOriginAuthentication.prototype.login.restore();
+        }
+        if (CrossOriginAuthentication.prototype.callback.restore) {
+          CrossOriginAuthentication.prototype.callback.restore();
+        }
+      });
+      it('should call `crossOriginAuthentication.login` with phoneNumber', function(done) {
+        var expectedOptions = {
+          credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+          realm: 'sms',
+          username: '+55165134',
+          otp: '123456'
+        };
+        stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+
+        this.auth0.passwordlessLogin(
+          {
+            connection: 'sms',
+            phoneNumber: '+55165134',
+            verificationCode: '123456'
+          },
+          function(err, data) {
+            return 'cb';
+          }
+        );
+      });
+      it('should call `crossOriginAuthentication.login` with email', function(done) {
+        var expectedOptions = {
+          credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
+          realm: 'email',
+          username: 'the@email.com',
+          otp: '123456'
+        };
+        stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+
+        this.auth0.passwordlessLogin(
+          {
+            connection: 'email',
+            email: 'the@email.com',
+            verificationCode: '123456'
+          },
+          function(err, data) {
+            return 'cb';
+          }
+        );
+      });
+    });
+    context.only('when inside of the universal login page', function() {
+      beforeEach(function() {
+        stub(windowHelper, 'getWindow', function() {
+          return {
+            location: {
+              host: 'me.auth0.com'
+            }
+          };
+        });
+      });
+
+      afterEach(function() {
+        windowHelper.getWindow.restore();
+      });
+      it('should call `webauth.passwordlessVerify` with phoneNumber', function(done) {
+        var expectedOptions = {
           connection: 'sms',
           phoneNumber: '+55165134',
           verificationCode: '123456'
-        },
-        function(err, data) {
-          return 'cb';
-        }
-      );
-    });
-    it('should call `crossOriginAuthentication.login` with email', function(done) {
-      var expectedOptions = {
-        credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
-        realm: 'email',
-        username: 'the@email.com',
-        otp: '123456'
-      };
-      stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
-        expect(options).to.be.eql(expectedOptions);
-        expect(cb()).to.be('cb');
-        done();
-      });
+        };
+        stub(this.auth0, 'passwordlessVerify', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
 
-      this.auth0.passwordlessLogin(
-        {
+        this.auth0.passwordlessLogin(
+          {
+            connection: 'sms',
+            phoneNumber: '+55165134',
+            verificationCode: '123456'
+          },
+          function(err, data) {
+            return 'cb';
+          }
+        );
+      });
+      it('should call `webauth.passwordlessVerify` with email', function(done) {
+        var expectedOptions = {
           connection: 'email',
           email: 'the@email.com',
           verificationCode: '123456'
-        },
-        function(err, data) {
-          return 'cb';
-        }
-      );
+        };
+        stub(this.auth0, 'passwordlessVerify', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+
+        this.auth0.passwordlessLogin(
+          {
+            connection: 'email',
+            email: 'the@email.com',
+            verificationCode: '123456'
+          },
+          function(err, data) {
+            return 'cb';
+          }
+        );
+      });
     });
   });
 

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -12,6 +12,7 @@ var RequestMock = require('../mock/request-mock');
 var TransactionManager = require('../../src/web-auth/transaction-manager');
 var SilentAuthenticationHandler = require('../../src/web-auth/silent-authentication-handler');
 var CrossOriginAuthentication = require('../../src/web-auth/cross-origin-authentication');
+var HostedPages = require('../../src/web-auth/hosted-pages');
 var IframeHandler = require('../../src/helper/iframe-handler');
 
 var objectHelper = require('../../src/helper/object');
@@ -1568,7 +1569,80 @@ describe('auth0.WebAuth', function() {
       );
     });
   });
-  context('crossOriginAuthentication', function() {
+  context('login', function() {
+    context('when outside of the universal login page', function() {
+      before(function() {
+        this.auth0 = new WebAuth({
+          domain: 'me.auth0.com',
+          clientID: '...',
+          redirectUri: 'http://page.com/callback',
+          responseType: 'token',
+          _sendTelemetry: false
+        });
+      });
+      beforeEach(function() {
+        stub(windowHelper, 'getWindow', function() {
+          return {
+            location: {
+              host: 'other-domain.auth0.com'
+            }
+          };
+        });
+      });
+
+      afterEach(function() {
+        windowHelper.getWindow.restore();
+        CrossOriginAuthentication.prototype.login.restore();
+      });
+
+      it('should call CrossOriginAuthentication.login', function(done) {
+        var expectedOptions = { foo: 'bar' };
+        stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+        this.auth0.login(expectedOptions, function() {
+          return 'cb';
+        });
+      });
+    });
+    context('when inside of the universal login page', function() {
+      before(function() {
+        this.auth0 = new WebAuth({
+          domain: 'me.auth0.com',
+          clientID: '...',
+          redirectUri: 'http://page.com/callback',
+          responseType: 'token',
+          _sendTelemetry: false
+        });
+      });
+      beforeEach(function() {
+        stub(windowHelper, 'getWindow', function() {
+          return {
+            location: {
+              host: 'me.auth0.com'
+            }
+          };
+        });
+      });
+      afterEach(function() {
+        windowHelper.getWindow.restore();
+      });
+      it('calls _hostedPages.login mapping the connection parameter', function(done) {
+        var expectedOptions = { connection: 'bar' };
+        stub(HostedPages.prototype, 'login', function(options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+        this.auth0.login({ realm: 'bar' }, function() {
+          return 'cb';
+        });
+      });
+    });
+  });
+  context('cross origin callbacks', function() {
     before(function() {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
@@ -1580,24 +1654,7 @@ describe('auth0.WebAuth', function() {
     });
 
     afterEach(function() {
-      if (CrossOriginAuthentication.prototype.login.restore) {
-        CrossOriginAuthentication.prototype.login.restore();
-      }
-      if (CrossOriginAuthentication.prototype.callback.restore) {
-        CrossOriginAuthentication.prototype.callback.restore();
-      }
-    });
-
-    it('should call login', function(done) {
-      var expectedOptions = { foo: 'bar' };
-      stub(CrossOriginAuthentication.prototype, 'login', function(options, cb) {
-        expect(options).to.be.eql(expectedOptions);
-        expect(cb()).to.be('cb');
-        done();
-      });
-      this.auth0.login(expectedOptions, function() {
-        return 'cb';
-      });
+      CrossOriginAuthentication.prototype.callback.restore();
     });
     it('should call callback with deprecated method `crossOriginAuthenticationCallback`', function(
       done


### PR DESCRIPTION
This is bringing usernamepassword/login back to auth0.js. It's the same code as the v8 branch, I just added a check to make sure you can only call that method from the universal login page. the `_hostedPages` object is not final and it's subject to change.