### PR TITLE
Use webAuth.login when calling signupAndLogin to support Univeral Login Page

### DIFF
--- a/src/web-auth/redirect.js
+++ b/src/web-auth/redirect.js
@@ -2,6 +2,7 @@ var CrossOriginAuthentication = require('./cross-origin-authentication');
 var Warn = require('../helper/warn');
 
 function Redirect(auth0, options) {
+  this.webAuth = auth0;
   this.baseOptions = options;
   this.client = auth0.client;
   this.crossOriginAuthentication = new CrossOriginAuthentication(auth0, this.baseOptions);
@@ -47,7 +48,9 @@ Redirect.prototype.signupAndLogin = function(options, cb) {
     if (err) {
       return cb(err);
     }
-    return _this.loginWithCredentials(options, cb);
+    options.realm = options.realm || options.connection;
+    delete options.connection;
+    return _this.webAuth.login(options, cb);
   });
 };
 

--- a/src/web-auth/redirect.js
+++ b/src/web-auth/redirect.js
@@ -4,7 +4,6 @@ var Warn = require('../helper/warn');
 function Redirect(auth0, options) {
   this.webAuth = auth0;
   this.baseOptions = options;
-  this.client = auth0.client;
   this.crossOriginAuthentication = new CrossOriginAuthentication(auth0, this.baseOptions);
 
   this.warn = new Warn({
@@ -44,7 +43,7 @@ Redirect.prototype.loginWithCredentials = function(options, cb) {
  */
 Redirect.prototype.signupAndLogin = function(options, cb) {
   var _this = this;
-  return this.client.dbConnection.signup(options, function(err) {
+  return this.webAuth.client.dbConnection.signup(options, function(err) {
     if (err) {
       return cb(err);
     }

--- a/test/web-auth/redirect.test.js
+++ b/test/web-auth/redirect.test.js
@@ -164,7 +164,13 @@ describe('auth0.WebAuth.redirect', function() {
           }
         });
       });
-      stub(this.auth0.redirect, 'loginWithCredentials', function(options, cb) {
+      stub(this.auth0, 'login', function(options, cb) {
+        expect(options).to.be.eql({
+          email: 'me@example.com',
+          password: '123456',
+          scope: 'openid',
+          realm: 'the_connection'
+        });
         done();
       });
 


### PR DESCRIPTION
IN order to make `webauth.client.signupAndLogin` support the HLP, we need to make it sure that we call the `webauth.login` after the signup, since this method will pick the right endpoint to login