### PR TITLE
Fix inconsistent cross origin error handling

### DIFF
--- a/src/web-auth/cross-origin-authentication.js
+++ b/src/web-auth/cross-origin-authentication.js
@@ -4,6 +4,7 @@ var windowHelper = require('../helper/window');
 var objectHelper = require('../helper/object');
 var RequestBuilder = require('../helper/request-builder');
 var WebMessageHandler = require('./web-message-handler');
+var responseHandler = require('../helper/response-handler');
 
 function CrossOriginAuthentication(webAuth, options) {
   this.webAuth = webAuth;
@@ -70,7 +71,7 @@ CrossOriginAuthentication.prototype.login = function(options, cb) {
         error: 'request_error',
         error_description: JSON.stringify(err)
       };
-      return cb(errorObject);
+      return responseHandler(cb)(errorObject);
     }
     var popupMode = options.popup === true;
     options = objectHelper.blacklist(options, ['password', 'credentialType', 'otp', 'popup']);

--- a/test/web-auth/cross-origin-authentication.test.js
+++ b/test/web-auth/cross-origin-authentication.test.js
@@ -252,7 +252,7 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
                   response: {
                     body: {
                       error: 'any_error',
-                      error_description: 'any error'
+                      error_description: 'a super big error message description'
                     }
                   }
                 });
@@ -268,9 +268,9 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
             },
             function(err) {
               expect(err).to.be.eql({
-                original: { error: 'any_error', error_description: 'any error' },
+                original: { error: 'any_error', error_description: 'a super big error message description' },
                 code: 'any_error',
-                description: 'any error'
+                description: 'a super big error message description'
               });
               expect(_this.webAuthSpy.authorize.called).to.be.eql(false);
               done();

--- a/test/web-auth/cross-origin-authentication.test.js
+++ b/test/web-auth/cross-origin-authentication.test.js
@@ -267,7 +267,11 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
               anotherOption: 'foobar'
             },
             function(err) {
-              expect(err).to.be.eql({ error: 'any_error', error_description: 'any error' });
+              expect(err).to.be.eql({
+                original: { error: 'any_error', error_description: 'any error' },
+                code: 'any_error',
+                description: 'any error'
+              });
               expect(_this.webAuthSpy.authorize.called).to.be.eql(false);
               done();
             }
@@ -300,8 +304,12 @@ describe('auth0.WebAuth.crossOriginAuthentication', function() {
             },
             function(err) {
               expect(err).to.be.eql({
-                error: 'request_error',
-                error_description: '{"some":"error"}'
+                original: {
+                  error: 'request_error',
+                  error_description: '{"some":"error"}'
+                },
+                code: 'request_error',
+                description: '{"some":"error"}'
               });
               expect(_this.webAuthSpy.authorize.called).to.be.eql(false);
               done();


### PR DESCRIPTION
We weren't applying the error mapping that we do in other errors.