### PR TITLE
Removed warning notice for HLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 Client Side Javascript toolkit for Auth0 API
 
-> Auth0.js v9 uses our latest embedded login API. This version **cannot be used inside Auth0-Hosted Login Pages**. If you are using a Hosted Login Page, keep using Auth0.js v8.
-
 Need help migrating from v8? Please check our [Migration Guide](https://auth0.com/docs/libraries/auth0js/v9/migration-guide)
 
 If you want to read the full API documentation of auth0.js, see [here](https://auth0.github.io/auth0.js/index.html)


### PR DESCRIPTION
Auth0.js can now safely be used in the Hosted Login Page after v9.2