### PR TITLE
Add audience:/userinfo to getSSOData checkSession call

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -393,7 +393,8 @@ Authentication.prototype.getSSOData = function(withActiveDirectories, cb) {
       responseType: 'token id_token',
       scope: 'openid profile email',
       connection: ssodataInformation.lastUsedConnection,
-      timeout: 5000
+      timeout: 5000,
+      audience: urljoin(this.baseOptions.rootUrl, 'userinfo')
     },
     function(err, result) {
       if (err) {

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -308,7 +308,8 @@ describe('auth0.authentication', function() {
         responseType: 'token id_token',
         scope: 'openid profile email',
         connection: 'lastUsedConnection',
-        timeout: 5000
+        timeout: 5000,
+        audience: 'https://me.auth0.com/userinfo'
       });
     });
     it('returns sso:false if checkSession fails', function(done) {


### PR DESCRIPTION
This prevents auth0-server to return an error when the profile is too big to be returned. This also doesn't affect the end result, considering we only need the `email` and `name` parameters.