### PR TITLE
Fix issue #1235 - origin check and sending origin param

### DIFF
--- a/src/helper/object.js
+++ b/src/helper/object.js
@@ -119,7 +119,8 @@ function toCamelCase(object, exceptions) {
 
 function getLocationFromUrl(href) {
   var match = href.match(
-    /^(https?:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
+    // @see https://tools.ietf.org/html/rfc3986
+    /^([a-zA-Z]+[a-zA-Z0-9+\-.]*:)?\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
   );
   return (
     match && {

--- a/src/web-auth/web-message-handler.js
+++ b/src/web-auth/web-message-handler.js
@@ -39,9 +39,13 @@ WebMessageHandler.prototype.run = function(options, cb) {
   options.responseMode = 'web_message';
   options.prompt = 'none';
 
-  var currentOrigin = windowHelper.getOrigin();
+  var currentOrigin = (options.origin = windowHelper.getOrigin());
   var redirectUriOrigin = objectHelper.getOriginFromUrl(options.redirectUri);
-  if (redirectUriOrigin && currentOrigin !== redirectUriOrigin) {
+  if (
+    redirectUriOrigin &&
+    currentOrigin !== redirectUriOrigin &&
+    ['file://', 'null'].indexOf(currentOrigin) === -1
+  ) {
     return cb({
       error: 'origin_mismatch',
       error_description: "The redirectUri's origin (" +

--- a/test/helper/object.test.js
+++ b/test/helper/object.test.js
@@ -562,6 +562,26 @@ describe('helpers', function() {
         pathname: '',
         search: '',
         hash: '#access_token=foo'
+      },
+      'file:///data/user/0/com.acme.app/cache/app.html': {
+        href: 'file:///data/user/0/com.acme.app/cache/app.html',
+        protocol: 'file:',
+        host: '',
+        hostname: '',
+        port: undefined,
+        pathname: '/data/user/0/com.acme.app/cache/app.html',
+        search: '',
+        hash: ''
+      },
+      'acme-corp://': {
+        href: 'acme-corp://',
+        protocol: 'acme-corp:',
+        host: '',
+        hostname: '',
+        port: undefined,
+        pathname: '',
+        search: '',
+        hash: ''
       }
     };
     for (const url in mapping) {


### PR DESCRIPTION
Fix 2) for https://github.com/auth0/lock/issues/1235

- use origin instead of redirectUrl for origin check in postMessage @see https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage and https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
- Fix `Uncaught TypeError: Cannot read property 'protocol' of null` for redirectUrl with protocol other than http(s). RFC https://tools.ietf.org/html/rfc3986 cc. @GabrielArakaki 