### PR TITLE
Use CookieStorage when localStorage is not available

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -201,7 +201,7 @@
 
     var webAuth = new auth0.WebAuth({
       domain: 'brucke.auth0.com',
-      redirectUri: 'https://localhost:3000/example',
+      redirectUri: 'https://localhost:3000/example/',
       clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
       responseType: 'token',
       plugins: [
@@ -211,7 +211,7 @@
 
     var webAuthPasswordless = new auth0.WebAuth({
       domain: 'brucke.auth0.com',
-      redirectUri: 'https://localhost:3000/example',
+      redirectUri: 'https://localhost:3000/example/',
       clientID: 'VZUvmnj3pd9yNgq8BjX4YA8Km14jQ0PN',
       responseType: 'token'
     });

--- a/src/helper/storage/handler.js
+++ b/src/helper/storage/handler.js
@@ -5,7 +5,14 @@ var Warn = require('../warn');
 
 function StorageHandler() {
   this.warn = new Warn({});
-  this.storage = windowHandler.getWindow().localStorage || new CookieStorage();
+  this.storage = new CookieStorage();
+  try {
+    // some browsers throw an error when trying to access localStorage
+    // when localStorage is disabled.
+    this.storage = windowHandler.getWindow().localStorage;
+  } catch (e) {
+    this.warn.warning("Can't use localStorage. Using CookieStorage instead.");
+  }
 }
 
 StorageHandler.prototype.failover = function() {

--- a/test/helper/storage-handler.test.js
+++ b/test/helper/storage-handler.test.js
@@ -17,7 +17,7 @@ MockLocalStorage.prototype.setItem = function() {
   throw new Error('fail');
 };
 
-describe('helpers storage handler', function() {
+describe.ly('helpers storage handler', function() {
   it('should use localStorage by default', function() {
     stub(windowHandler, 'getWindow', function(message) {
       return {
@@ -31,9 +31,21 @@ describe('helpers storage handler', function() {
     windowHandler.getWindow.restore();
   });
 
-  it('should use cookie storage is localstorage is not available', function() {
+  it('should use cookie storage when localstorage is not available', function() {
+    stub(windowHandler, 'getWindow', function(message) {});
+
+    var handler = new StorageHandler();
+    expect(handler.storage).to.be.a(CookieStorage);
+
+    windowHandler.getWindow.restore();
+  });
+  it('should use cookie storage when localstorage throws an error', function() {
     stub(windowHandler, 'getWindow', function(message) {
-      return {};
+      return {
+        get localStorage() {
+          throw new Error('asdasd');
+        }
+      };
     });
 
     var handler = new StorageHandler();

--- a/test/helper/storage-handler.test.js
+++ b/test/helper/storage-handler.test.js
@@ -17,7 +17,7 @@ MockLocalStorage.prototype.setItem = function() {
   throw new Error('fail');
 };
 
-describe.ly('helpers storage handler', function() {
+describe('helpers storage handler', function() {
   it('should use localStorage by default', function() {
     stub(windowHandler, 'getWindow', function(message) {
       return {


### PR DESCRIPTION
some browsers throw an error when trying to access localStorage when localStorage is not available