### PR TITLE
Fixed typo in example page

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -175,7 +175,7 @@
         <input type="button" class="web-message-check-session" value="Check session" />
       </div>
       <div>
-        <h2>Get information about the last successful authorizatino request</h2>
+        <h2>Get information about the last successful authorization request</h2>
         <input type="button" class="getssodata" value="Get SSO data" />
       </div>
 


### PR DESCRIPTION
Noticed this small typo when running the example page locally and figured I'd fix it while I was in there.  

Thanks!