### PR TITLE
getSSOData should call /ssodata from the ULP

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -1,10 +1,11 @@
 var urljoin = require('url-join');
+var qs = require('qs');
 
 var RequestBuilder = require('../helper/request-builder');
-var qs = require('qs');
 var objectHelper = require('../helper/object');
 var assert = require('../helper/assert');
 var ssodata = require('../helper/ssodata');
+var windowHelper = require('../helper/window');
 var responseHandler = require('../helper/response-handler');
 var parametersWhitelist = require('../helper/parameters-whitelist');
 var Warn = require('../helper/warn');
@@ -380,6 +381,10 @@ Authentication.prototype.getSSOData = function(withActiveDirectories, cb) {
     // we can't import this in the constructor because it'd be a ciclic dependency
     var WebAuth = require('../web-auth/index'); // eslint-disable-line
     this.auth0 = new WebAuth(this.baseOptions);
+  }
+  var isHostedLoginPage = windowHelper.getWindow().location.host === this.baseOptions.domain;
+  if (isHostedLoginPage) {
+    return this.auth0._universalLogin.getSSOData(withActiveDirectories, cb);
   }
   if (typeof withActiveDirectories === 'function') {
     cb = withActiveDirectories;

--- a/test/web-auth/hosted-pages.test.js
+++ b/test/web-auth/hosted-pages.test.js
@@ -386,4 +386,67 @@ describe('auth0.WebAuth._universalLogin', function() {
       );
     });
   });
+
+  context('getSSOData', function() {
+    before(function() {
+      this.auth0 = new WebAuth({
+        domain: 'me.auth0.com',
+        clientID: '...',
+        redirectUri: 'http://page.com/callback',
+        responseType: 'code',
+        _sendTelemetry: false
+      });
+    });
+
+    afterEach(function() {
+      request.get.restore();
+    });
+
+    it('should call ssodata with all the options', function(done) {
+      stub(request, 'get', function(url) {
+        expect(url).to.be('https://me.auth0.com/user/ssodata/');
+        return new RequestMock({
+          headers: {},
+          cb: function(cb) {
+            cb(null, {
+              body: {
+                sso: false
+              }
+            });
+          }
+        });
+      });
+
+      this.auth0._universalLogin.getSSOData(function(err, data) {
+        expect(err).to.be(null);
+        expect(data).to.eql({
+          sso: false
+        });
+        done();
+      });
+    });
+    it('should call ssodata with all the ad options', function(done) {
+      stub(request, 'get', function(url) {
+        expect(url).to.be('https://me.auth0.com/user/ssodata?ldaps=1&client_id=...');
+        return new RequestMock({
+          headers: {},
+          cb: function(cb) {
+            cb(null, {
+              body: {
+                sso: false
+              }
+            });
+          }
+        });
+      });
+
+      this.auth0._universalLogin.getSSOData(true, function(err, data) {
+        expect(err).to.be(null);
+        expect(data).to.eql({
+          sso: false
+        });
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
currently, lock [does this](https://github.com/auth0/lock/blob/master/src/core/web_api/p2_api.js#L120) already, but auth0.js will always use checkSession, which is not supported in the ULP. This PR adds compatibility to the ULP when you want to call getssodata.