### PR TITLE
restore lazy instantiation of StorageHandler()

### DIFF
--- a/src/helper/storage.js
+++ b/src/helper/storage.js
@@ -1,9 +1,16 @@
 var StorageHandler = require('./storage/handler');
-var storage = new StorageHandler();
+var storage = false;
+
+function getStorage(force) {
+  if (!storage || force) {
+    storage = new StorageHandler();
+  }
+  return storage;
+}
 
 module.exports = {
   getItem: function(key) {
-    var value = storage.getItem(key);
+    var value = getStorage().getItem(key);
     try {
       return JSON.parse(value);
     } catch (_) {
@@ -11,10 +18,13 @@ module.exports = {
     }
   },
   removeItem: function(key) {
-    return storage.removeItem(key);
+    return getStorage().removeItem(key);
   },
   setItem: function(key, value, options) {
     var json = JSON.stringify(value);
-    return storage.setItem(key, json, options);
+    return getStorage().setItem(key, json, options);
+  },
+  reload: function() {
+    getStorage(true);
   }
 };


### PR DESCRIPTION
to avoid instantiating the StorageHandler, which requires the global window object, upon module load

bug was introduced in https://github.com/auth0/auth0.js/pull/737

addresses issue: https://github.com/auth0/auth0.js/issues/744