### PR TITLE
Issue: Fix issue when there is a hash in URL

### DIFF
--- a/src/web-auth/cross-origin-authentication.js
+++ b/src/web-auth/cross-origin-authentication.js
@@ -19,9 +19,10 @@ function getFragment(name) {
   var theWindow = windowHelper.getWindow();
   var value = '&' + theWindow.location.hash.substring(1);
   var parts = value.split('&' + name + '=');
-  if (parts.length === 2) {
-    return parts.pop().split('&').shift();
+  if (parts.length !== 2) {
+    parts = value.split('#' + name + '=');
   }
+  return parts.pop().split('&').shift();
 }
 
 function createKey(origin, coId) {


### PR DESCRIPTION
We are trying to add crossOriginFallback functionality in our node js application for Safari Browser.

In our application, we use history module - https://www.npmjs.com/package/history to create a history object. In particular we use createHashHistory which creates(or expects) a # in front of url's. 

So all URL's in our route needs to have '#' at the begining, such as 'https://domainname/#/login', 'https://domainname/#/landingpage' etc.

In case of crossOriginFallback, the URL generated by Safari is 'https://domainname/#/login/crossOriginFallback#origin=https://vicinity-retailer-dev.au.auth0.com'.

The current logic in https://github.com/auth0/auth0.js/blob/master/src/web-auth/cross-origin-authentication.js#L20 to come up with the 'origin' value using the url will break due to this. This is because we now have 2 hash values in the URL. 

The PR is to fix this issue