### PR TITLE
Add SRI hashes to the cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "codecov": "^1.0.1",
-    "component-cdn-uploader": "auth0/component-cdn-uploader#v1.3.0",
+    "component-cdn-uploader": "auth0/component-cdn-uploader#v2.1.0",
     "eslint": "3.12.2",
     "eslint-config-auth0-base": "6.0.0",
     "eslint-config-prettier": "^2.1.0",
@@ -87,12 +87,16 @@
     "sinon": "^1.17.6",
     "yargs": "^11.0.0"
   },
-  "cdn-component": {
+  "ccu": {
     "name": "auth0",
     "cdn": "https://cdn.auth0.com",
     "mainBundleFile": "auth0.min.js",
     "bucket": "assets.us.auth0.com",
-    "localPath": "dist"
+    "localPath": "dist",
+    "digest": {
+      "hashes": ["sha384"],
+      "extensions": [".js"]
+    }
   },
   "lint-staged": {
     "{src,test, plugins,integration}/**/*.js": [


### PR DESCRIPTION
Using this new options, cdn files will have the SRI hashes so you can properly check for integrity (https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)

related: https://github.com/auth0/component-cdn-uploader/issues/4