### PR TITLE
options is optional in WebAuth.prototype.authorize

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -360,7 +360,7 @@ WebAuth.prototype.validateToken = function(token, nonce, cb) {
  * Watch out! If you're not using the hosted login page to do social logins, you have to use your own [social connection keys](https://manage.auth0.com/#/connections/social). If you use Auth0's dev keys, you'll always get `login_required` as an error when calling this method.
  *
  * @method renewAuth
- * @param {Object} options
+ * @param {Object} [options]
  * @param {String} [options.clientID] the Client ID found on your Application settings page
  * @param {String} [options.redirectUri] url that the Auth0 will redirect after Auth with the Authorization Response
  * @param {String} [options.responseType] type of the response used by OAuth 2.0 flow. It can be any space separated list of the values `code`, `token`, `id_token`. {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0}
@@ -435,7 +435,7 @@ WebAuth.prototype.renewAuth = function(options, cb) {
  * Renews an existing session on Auth0's servers using `response_mode=web_message`
  *
  * @method checkSession
- * @param {Object} options
+ * @param {Object} [options]
 
  * @param {String} [options.clientID] the Client ID found on your Application settings page
  * @param {String} [options.responseType] type of the response used by OAuth 2.0 flow. It can be any space separated list of the values `code`, `token`, `id_token`. {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0}
@@ -731,7 +731,7 @@ WebAuth.prototype.crossOriginVerification = function() {
  * - If the client_id parameter is NOT included, the returnTo URL must be listed in the Allowed Logout URLs set at the account level (see Setting Allowed Logout URLs at the Account Level).
  *
  * @method logout
- * @param {Object} options
+ * @param {Object} [options]
  * @param {String} [options.clientID] the Client ID found on your Application settings page
  * @param {String} [options.returnTo] URL to be redirected after the logout
  * @param {Boolean} [options.federated] tells Auth0 if it should logout the user also from the IdP.

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -541,7 +541,7 @@ WebAuth.prototype.signup = function(options, cb) {
  * After that, you'll have to use the {@link parseHash} function at the specified `redirectUri`.
  *
  * @method authorize
- * @param {Object} options
+ * @param {Object} [options]
  * @param {String} [options.clientID] the Client ID found on your Application settings page
  * @param {String} options.redirectUri url that the Auth0 will redirect after Auth with the Authorization Response
  * @param {String} options.responseType type of the response used by OAuth 2.0 flow. It can be any space separated list of the values `code`, `token`, `id_token`. {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0}


### PR DESCRIPTION
In your tutorials, `authorize` is called without any arguments ([example](https://auth0.com/docs/quickstart/spa/jquery/01-login#create-an-authentication-service)).

Consequently, `options` should be marked as optional in the JsDoc (i.e. `[options]`), otherwise IDEs might warn that its invocations require 1 argument:

![screenshot from 2018-07-06 23-03-25](https://user-images.githubusercontent.com/18451/42380352-ee875f8a-8170-11e8-9011-aba1db7a6985.png)
