### PR TITLE
Start using cookies instead of localStorage by default

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -4,7 +4,7 @@ import qs from 'qs';
 import RequestBuilder from '../helper/request-builder';
 import objectHelper from '../helper/object';
 import assert from '../helper/assert';
-import ssodata from '../helper/ssodata';
+import SSODataStorage from '../helper/ssodata';
 import windowHelper from '../helper/window';
 import responseHandler from '../helper/response-handler';
 import parametersWhitelist from '../helper/parameters-whitelist';
@@ -81,6 +81,7 @@ function Authentication(auth0, options) {
   this.warn = new Warn({
     disableWarnings: !!options._disableDeprecationWarnings
   });
+  this.ssodataStorage = new SSODataStorage(this.baseOptions);
 }
 
 /**
@@ -393,7 +394,7 @@ Authentication.prototype.getSSOData = function(withActiveDirectories, cb) {
   }
   assert.check(cb, { type: 'function', message: 'cb parameter is not valid' });
   var clientId = this.baseOptions.clientID;
-  var ssodataInformation = ssodata.get() || {};
+  var ssodataInformation = this.ssodataStorage.get() || {};
 
   this.auth0.checkSession(
     {

--- a/src/helper/ssodata.js
+++ b/src/helper/ssodata.js
@@ -1,18 +1,22 @@
-import storage from './storage';
+import Storage from './storage';
 
-export default {
-  set: function(connection, sub) {
-    var ssodata = {
-      lastUsedConnection: connection,
-      lastUsedSub: sub
-    };
-    storage.setItem('auth0.ssodata', JSON.stringify(ssodata));
-  },
-  get: function() {
-    var ssodata = storage.getItem('auth0.ssodata');
-    if (!ssodata) {
-      return;
-    }
-    return JSON.parse(ssodata);
-  }
+function SSODataStorage(options) {
+  this.storage = new Storage(options);
+}
+
+SSODataStorage.prototype.set = function(connection, sub) {
+  var ssodata = {
+    lastUsedConnection: connection,
+    lastUsedSub: sub
+  };
+  this.storage.setItem('auth0.ssodata', JSON.stringify(ssodata));
 };
+SSODataStorage.prototype.get = function() {
+  var ssodata = this.storage.getItem('auth0.ssodata');
+  if (!ssodata) {
+    return;
+  }
+  return JSON.parse(ssodata);
+};
+
+export default SSODataStorage;

--- a/src/helper/storage.js
+++ b/src/helper/storage.js
@@ -1,26 +1,23 @@
 import StorageHandler from './storage/handler';
-var storage;
-var getStorage = function() {
-  if (!storage) {
-    storage = new StorageHandler();
+
+function Storage(options) {
+  this.handler = new StorageHandler(options);
+}
+
+Storage.prototype.getItem = function(key) {
+  var value = this.handler.getItem(key);
+  try {
+    return JSON.parse(value);
+  } catch (_) {
+    return value;
   }
-  return storage;
+};
+Storage.prototype.removeItem = function(key) {
+  return this.handler.removeItem(key);
+};
+Storage.prototype.setItem = function(key, value, options) {
+  var json = JSON.stringify(value);
+  return this.handler.setItem(key, json, options);
 };
 
-export default {
-  getItem: function(key) {
-    var value = getStorage().getItem(key);
-    try {
-      return JSON.parse(value);
-    } catch (_) {
-      return value;
-    }
-  },
-  removeItem: function(key) {
-    return getStorage().removeItem(key);
-  },
-  setItem: function(key, value, options) {
-    var json = JSON.stringify(value);
-    return getStorage().setItem(key, json, options);
-  }
-};
+export default Storage;

--- a/src/helper/storage/handler.js
+++ b/src/helper/storage/handler.js
@@ -6,7 +6,7 @@ import Warn from '../warn';
 function StorageHandler(options) {
   this.warn = new Warn({});
   this.storage = new CookieStorage();
-  if (!options.__tryLocalStorageFirst) {
+  if (options.__tryLocalStorageFirst !== true) {
     return;
   }
   try {

--- a/src/helper/storage/handler.js
+++ b/src/helper/storage/handler.js
@@ -3,9 +3,12 @@ import DummyStorage from './dummy';
 import CookieStorage from './cookie';
 import Warn from '../warn';
 
-function StorageHandler() {
+function StorageHandler(options) {
   this.warn = new Warn({});
   this.storage = new CookieStorage();
+  if (!options.__tryLocalStorageFirst) {
+    return;
+  }
   try {
     // some browsers throw an error when trying to access localStorage
     // when localStorage is disabled.

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -6,7 +6,7 @@ import qs from 'qs';
 import PluginHandler from '../helper/plugins';
 import windowHelper from '../helper/window';
 import objectHelper from '../helper/object';
-import ssodata from '../helper/ssodata';
+import SSODataStorage from '../helper/ssodata';
 import TransactionManager from './transaction-manager';
 import Authentication from '../authentication';
 import Redirect from './redirect';
@@ -115,6 +115,7 @@ function WebAuth(options) {
   this.crossOriginAuthentication = new CrossOriginAuthentication(this, this.baseOptions);
   this.webMessageHandler = new WebMessageHandler(this);
   this._universalLogin = new HostedPages(this, this.baseOptions);
+  this.ssodataStorage = new SSODataStorage(this.baseOptions);
 }
 
 /**
@@ -245,7 +246,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(options, parsedHash,
       if (payload) {
         sub = payload.sub;
       }
-      ssodata.set(transaction.lastUsedConnection, sub);
+      _this.ssodataStorage.set(transaction.lastUsedConnection, sub);
     }
     return cb(null, buildParseHashResponse(parsedHash, appState, payload));
   };

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -107,7 +107,7 @@ function WebAuth(options) {
 
   this.baseOptions.jwksURI = this.baseOptions.overrides && this.baseOptions.overrides.__jwks_uri;
 
-  this.transactionManager = new TransactionManager(this.baseOptions.transaction);
+  this.transactionManager = new TransactionManager(this.baseOptions);
 
   this.client = new Authentication(this.baseOptions);
   this.redirect = new Redirect(this, this.baseOptions);

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -17,7 +17,7 @@ function Popup(webAuth, options) {
   this.client = webAuth.client;
   this.webAuth = webAuth;
 
-  this.transactionManager = new TransactionManager(this.baseOptions.transaction);
+  this.transactionManager = new TransactionManager(this.baseOptions);
   this.crossOriginAuthentication = new CrossOriginAuthentication(webAuth, this.baseOptions);
   this.warn = new Warn({
     disableWarnings: !!options._disableDeprecationWarnings

--- a/src/web-auth/transaction-manager.js
+++ b/src/web-auth/transaction-manager.js
@@ -1,5 +1,5 @@
 import random from '../helper/random';
-import storage from '../helper/storage';
+import Storage from '../helper/storage';
 import * as times from '../helper/times';
 
 var DEFAULT_NAMESPACE = 'com.auth0.auth.';
@@ -8,6 +8,7 @@ function TransactionManager(options) {
   options = options || {};
   this.namespace = options.namespace || DEFAULT_NAMESPACE;
   this.keyLength = options.keyLength || 32;
+  this.storage = new Storage(options);
 }
 
 TransactionManager.prototype.process = function(options) {
@@ -45,7 +46,7 @@ TransactionManager.prototype.generateTransaction = function(
   state = state || random.randomString(this.keyLength);
   nonce = nonce || (generateNonce ? random.randomString(this.keyLength) : null);
 
-  storage.setItem(
+  this.storage.setItem(
     this.namespace + state,
     {
       nonce: nonce,
@@ -64,13 +65,13 @@ TransactionManager.prototype.generateTransaction = function(
 TransactionManager.prototype.getStoredTransaction = function(state) {
   var transactionData;
 
-  transactionData = storage.getItem(this.namespace + state);
+  transactionData = this.storage.getItem(this.namespace + state);
   this.clearTransaction(state);
   return transactionData;
 };
 
 TransactionManager.prototype.clearTransaction = function(state) {
-  storage.removeItem(this.namespace + state);
+  this.storage.removeItem(this.namespace + state);
 };
 
 export default TransactionManager;

--- a/src/web-auth/transaction-manager.js
+++ b/src/web-auth/transaction-manager.js
@@ -5,9 +5,9 @@ import * as times from '../helper/times';
 var DEFAULT_NAMESPACE = 'com.auth0.auth.';
 
 function TransactionManager(options) {
-  options = options || {};
-  this.namespace = options.namespace || DEFAULT_NAMESPACE;
-  this.keyLength = options.keyLength || 32;
+  var transaction = options.transaction || {};
+  this.namespace = transaction.namespace || DEFAULT_NAMESPACE;
+  this.keyLength = transaction.keyLength || 32;
   this.storage = new Storage(options);
 }
 

--- a/src/web-auth/username-password.js
+++ b/src/web-auth/username-password.js
@@ -9,7 +9,7 @@ import TransactionManager from './transaction-manager';
 function UsernamePassword(options) {
   this.baseOptions = options;
   this.request = new RequestBuilder(options);
-  this.transactionManager = new TransactionManager(this.baseOptions.transaction);
+  this.transactionManager = new TransactionManager(this.baseOptions);
 }
 
 UsernamePassword.prototype.login = function(options, cb) {

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -8,7 +8,7 @@ import request from 'superagent';
 
 import RequestBuilder from '../../src/helper/request-builder';
 import windowHelper from '../../src/helper/window';
-import storage from '../../src/helper/storage';
+import Storage from '../../src/helper/storage';
 import Authentication from '../../src/authentication';
 import WebAuth from '../../src/web-auth';
 
@@ -279,7 +279,7 @@ describe('auth0.authentication', function() {
           responseType: 'code',
           _sendTelemetry: false
         });
-        stub(storage, 'getItem', function(key) {
+        stub(Storage.prototype, 'getItem', function(key) {
           expect(key).to.be('auth0.ssodata');
           return JSON.stringify({
             lastUsedConnection: 'lastUsedConnection',
@@ -289,7 +289,7 @@ describe('auth0.authentication', function() {
         });
       });
       after(function() {
-        storage.getItem.restore();
+        Storage.prototype.getItem.restore();
       });
       beforeEach(function() {
         stub(windowHelper, 'getWindow', function() {

--- a/test/helper/ssodata.test.js
+++ b/test/helper/ssodata.test.js
@@ -1,30 +1,34 @@
 import expect from 'expect.js';
 import { stub } from 'sinon';
 
-import storage from '../../src/helper/storage';
-import ssodata from '../../src/helper/ssodata';
+import Storage from '../../src/helper/storage';
+import SSODataStorage from '../../src/helper/ssodata';
 
 describe('helpers', function() {
+  var ssodata;
+  beforeEach(function() {
+    ssodata = new SSODataStorage({});
+  });
   describe('ssodata', function() {
     afterEach(function() {
-      if (storage.setItem.restore) {
-        storage.setItem.restore();
+      if (Storage.prototype.setItem.restore) {
+        Storage.prototype.setItem.restore();
       }
-      if (storage.getItem.restore) {
-        storage.getItem.restore();
+      if (Storage.prototype.getItem.restore) {
+        Storage.prototype.getItem.restore();
       }
     });
     describe('get', function() {
       it('when there is data', function() {
         var expectedObject = { foo: 'bar' };
-        stub(storage, 'getItem', function() {
+        stub(Storage.prototype, 'getItem', function() {
           return JSON.stringify(expectedObject);
         });
         var data = ssodata.get();
         expect(data).to.be.eql(expectedObject);
       });
       it('when there is no data', function() {
-        stub(storage, 'getItem', function() {
+        stub(Storage.prototype, 'getItem', function() {
           return undefined;
         });
         var data = ssodata.get();
@@ -33,7 +37,7 @@ describe('helpers', function() {
     });
     describe('set', function() {
       it('sets ssodata', function(done) {
-        stub(storage, 'setItem', function(key, value) {
+        stub(Storage.prototype, 'setItem', function(key, value) {
           expect(key).to.be('auth0.ssodata');
           expect(JSON.parse(value)).to.be.eql({
             lastUsedConnection: 'connection',

--- a/test/helper/storage-handler.test.js
+++ b/test/helper/storage-handler.test.js
@@ -78,7 +78,7 @@ describe('helpers storage handler', function() {
     });
   });
   describe('should use cookie storage', function() {
-    it('when __tryLocalStorageFirst is true but localSTorage is not available', function() {
+    it('when __tryLocalStorageFirst is true but localStorage is not available', function() {
       windowHandler.getWindow.restore();
       stub(windowHandler, 'getWindow', function(message) {});
 

--- a/test/helper/storage.test.js
+++ b/test/helper/storage.test.js
@@ -1,11 +1,14 @@
 import expect from 'expect.js';
 import { stub, spy } from 'sinon';
 
-import windowHandler from '../../src/helper/window';
 import StorageHandler from '../../src/helper/storage/handler';
-import storage from '../../src/helper/storage';
+import Storage from '../../src/helper/storage';
 
 describe('helpers storage', function() {
+  var storage;
+  beforeEach(function() {
+    storage = new Storage({});
+  });
   describe('setItem', function() {
     beforeEach(function() {
       spy(StorageHandler.prototype, 'setItem');

--- a/test/web-auth/popup.test.js
+++ b/test/web-auth/popup.test.js
@@ -8,7 +8,7 @@ import request from 'superagent';
 
 import PopupHandler from '../../src/helper/popup-handler';
 import windowHandler from '../../src/helper/window';
-import storage from '../../src/helper/storage';
+import Storage from '../../src/helper/storage';
 import WebAuth from '../../src/web-auth';
 import CrossOriginAuthentication from '../../src/web-auth/cross-origin-authentication';
 import TransactionManager from '../../src/web-auth/transaction-manager';
@@ -94,11 +94,11 @@ describe('auth0.WebAuth.popup', function() {
         expect(url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&connection=the_connection&state=123&nonce=456&scope=openid'
         );
-        storage.setItem.restore();
+        Storage.prototype.setItem.restore();
         TransactionManager.prototype.process.restore();
         done();
       });
-      stub(storage, 'setItem', function() {});
+      stub(Storage.prototype, 'setItem', function() {});
       stub(TransactionManager.prototype, 'process', function(options) {
         return options;
       });

--- a/test/web-auth/transaction-manager.test.js
+++ b/test/web-auth/transaction-manager.test.js
@@ -2,9 +2,8 @@ import expect from 'expect.js';
 import { stub, spy } from 'sinon';
 
 import TransactionManager from '../../src/web-auth/transaction-manager';
-import objectHelper from '../../src/helper/object';
 import random from '../../src/helper/random';
-import storage from '../../src/helper/storage';
+import Storage from '../../src/helper/storage';
 
 context('TransactionManager', function() {
   beforeEach(function() {
@@ -77,18 +76,18 @@ context('TransactionManager', function() {
       stub(random, 'randomString', function() {
         return 'randomString';
       });
-      stub(storage, 'setItem');
+      stub(Storage.prototype, 'setItem');
     });
     afterEach(function() {
       random.randomString.restore();
-      storage.setItem.restore();
+      Storage.prototype.setItem.restore();
     });
     it('always stores random state', function() {
       var result = this.tm.generateTransaction('appState', null, null, null, false);
       expect(result).to.be.eql({ state: 'randomString', nonce: null });
-      expect(storage.setItem.calledOnce).to.be(true);
-      expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
-      expect(storage.setItem.lastCall.args[1]).to.be.eql({
+      expect(Storage.prototype.setItem.calledOnce).to.be(true);
+      expect(Storage.prototype.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
+      expect(Storage.prototype.setItem.lastCall.args[1]).to.be.eql({
         nonce: null,
         appState: 'appState',
         state: 'randomString',
@@ -98,9 +97,9 @@ context('TransactionManager', function() {
     it('only stores random nonce when generateNonce is true', function() {
       var result = this.tm.generateTransaction('appState', null, null, null, true);
       expect(result).to.be.eql({ state: 'randomString', nonce: 'randomString' });
-      expect(storage.setItem.calledOnce).to.be(true);
-      expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
-      expect(storage.setItem.lastCall.args[1]).to.be.eql({
+      expect(Storage.prototype.setItem.calledOnce).to.be(true);
+      expect(Storage.prototype.setItem.lastCall.args[0]).to.be('com.auth0.auth.randomString');
+      expect(Storage.prototype.setItem.lastCall.args[1]).to.be.eql({
         nonce: 'randomString',
         appState: 'appState',
         state: 'randomString',
@@ -110,9 +109,9 @@ context('TransactionManager', function() {
     it('uses nonce/state when provided', function() {
       var result = this.tm.generateTransaction('appState', 'state', 'nonce', null);
       expect(result).to.be.eql({ state: 'state', nonce: 'nonce' });
-      expect(storage.setItem.calledOnce).to.be(true);
-      expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
-      expect(storage.setItem.lastCall.args[1]).to.be.eql({
+      expect(Storage.prototype.setItem.calledOnce).to.be(true);
+      expect(Storage.prototype.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
+      expect(Storage.prototype.setItem.lastCall.args[1]).to.be.eql({
         nonce: 'nonce',
         appState: 'appState',
         state: 'state',
@@ -122,9 +121,9 @@ context('TransactionManager', function() {
     it('uses lastUsedConnection when provided', function() {
       var result = this.tm.generateTransaction('appState', 'state', 'nonce', 'lastUsedConnection');
       expect(result).to.be.eql({ state: 'state', nonce: 'nonce' });
-      expect(storage.setItem.calledOnce).to.be(true);
-      expect(storage.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
-      expect(storage.setItem.lastCall.args[1]).to.be.eql({
+      expect(Storage.prototype.setItem.calledOnce).to.be(true);
+      expect(Storage.prototype.setItem.lastCall.args[0]).to.be('com.auth0.auth.state');
+      expect(Storage.prototype.setItem.lastCall.args[1]).to.be.eql({
         nonce: 'nonce',
         appState: 'appState',
         state: 'state',
@@ -134,14 +133,14 @@ context('TransactionManager', function() {
   });
   context('getStoredTransaction', function() {
     beforeEach(function() {
-      stub(storage, 'getItem', function(state) {
+      stub(Storage.prototype, 'getItem', function(state) {
         expect(state).to.be('com.auth0.auth.state');
         return { from: 'storage' };
       });
       spy(TransactionManager.prototype, 'clearTransaction');
     });
     afterEach(function() {
-      storage.getItem.restore();
+      Storage.prototype.getItem.restore();
       TransactionManager.prototype.clearTransaction.restore();
     });
     it('returns transaction data from storage', function() {
@@ -155,15 +154,15 @@ context('TransactionManager', function() {
   });
   context('clearTransaction', function() {
     beforeEach(function() {
-      stub(storage, 'removeItem');
+      stub(Storage.prototype, 'removeItem');
     });
     afterEach(function() {
-      storage.removeItem.restore();
+      Storage.prototype.removeItem.restore();
     });
     it('removes data from storage', function() {
       this.tm.clearTransaction('state');
-      expect(storage.removeItem.calledOnce).to.be(true);
-      expect(storage.removeItem.lastCall.args[0]).to.be('com.auth0.auth.state');
+      expect(Storage.prototype.removeItem.calledOnce).to.be(true);
+      expect(Storage.prototype.removeItem.lastCall.args[0]).to.be('com.auth0.auth.state');
     });
   });
 });

--- a/test/web-auth/transaction-manager.test.js
+++ b/test/web-auth/transaction-manager.test.js
@@ -7,7 +7,7 @@ import Storage from '../../src/helper/storage';
 
 context('TransactionManager', function() {
   beforeEach(function() {
-    this.tm = new TransactionManager();
+    this.tm = new TransactionManager({});
   });
   context('process', function() {
     beforeEach(function() {

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -5,7 +5,7 @@ import request from 'superagent';
 import IdTokenVerifier from 'idtoken-verifier';
 
 import windowHelper from '../../src/helper/window';
-import ssodata from '../../src/helper/ssodata';
+import SSODataStorage from '../../src/helper/ssodata';
 import Warn from '../../src/helper/warn';
 
 import RequestMock from '../mock/request-mock';
@@ -266,13 +266,13 @@ describe('auth0.WebAuth', function() {
         state: 'foo',
         appState: null
       });
-      spy(ssodata, 'set');
+      spy(SSODataStorage.prototype, 'set');
       stub(IdTokenVerifier.prototype, 'validateAccessToken', function(at, alg, atHash, cb) {
         cb(null);
       });
     });
     afterEach(function() {
-      ssodata.set.restore();
+      SSODataStorage.prototype.set.restore();
       if (IdTokenVerifier.prototype.validateAccessToken.restore) {
         IdTokenVerifier.prototype.validateAccessToken.restore();
       }
@@ -569,8 +569,11 @@ describe('auth0.WebAuth', function() {
                 '#state=foo&access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
             },
             function() {
-              expect(ssodata.set.calledOnce).to.be.ok();
-              expect(ssodata.set.firstCall.args).to.be.eql(['lastUsedConnection', undefined]);
+              expect(SSODataStorage.prototype.set.calledOnce).to.be.ok();
+              expect(SSODataStorage.prototype.set.firstCall.args).to.be.eql([
+                'lastUsedConnection',
+                undefined
+              ]);
               expect(TransactionManager.prototype.getStoredTransaction.calledOnce).to.be.ok();
               done();
             }
@@ -584,8 +587,8 @@ describe('auth0.WebAuth', function() {
               nonce: 'wEOe7-LC8nl1AuHp7nucF_5LMVPVkMBY'
             },
             function() {
-              expect(ssodata.set.calledOnce).to.be.ok();
-              expect(ssodata.set.firstCall.args).to.be.eql([
+              expect(SSODataStorage.prototype.set.calledOnce).to.be.ok();
+              expect(SSODataStorage.prototype.set.firstCall.args).to.be.eql([
                 'lastUsedConnection',
                 'auth0|59fbe11937039b263a8b29a2'
               ]);
@@ -2316,7 +2319,7 @@ describe('auth0.WebAuth', function() {
       stub(TransactionManager.prototype, 'process', function(params) {
         return Object.assign({}, params, { from: 'transaction-manager' });
       });
-      spy(TransactionManager.prototype, 'clearTransaction');
+      stub(TransactionManager.prototype, 'clearTransaction', function() {});
       stub(windowHelper, 'getOrigin', function() {
         return 'https://test-origin.com';
       });


### PR DESCRIPTION
fix #402 #816 

In some cases, there's no way to old local storage entries because we don't have enough information:

- if the auth result wasn't successful
- if the cross origin auth was successful, but it didn't use the cross auth callback page

Because of that, cookies are a better fit for storage, since it has built-in expiration dates.

There's a new option `__tryLocalStorageFirst` that restores the previous behavior if you find any compatibility issues (please report them if you find it) or prefer to use localStorage for some reason.

This is not considered a breaking change because there shouldn't be any behavioral changes between versions.