### PR TITLE
fix(TransactionManager): Set state to expire in 30 mins

### DIFF
--- a/src/web-auth/transaction-manager.js
+++ b/src/web-auth/transaction-manager.js
@@ -54,7 +54,7 @@ TransactionManager.prototype.generateTransaction = function(
       state: state,
       lastUsedConnection: lastUsedConnection
     },
-    times.MINUTES_30
+    { expires: times.MINUTES_30 }
   );
   return {
     state: state,

--- a/test/web-auth/transaction-manager.test.js
+++ b/test/web-auth/transaction-manager.test.js
@@ -4,6 +4,7 @@ import { stub, spy } from 'sinon';
 import TransactionManager from '../../src/web-auth/transaction-manager';
 import random from '../../src/helper/random';
 import Storage from '../../src/helper/storage';
+import * as times from '../../src/helper/times';
 
 context('TransactionManager', function() {
   beforeEach(function() {
@@ -129,6 +130,12 @@ context('TransactionManager', function() {
         state: 'state',
         lastUsedConnection: 'lastUsedConnection'
       });
+    });
+    it('stores state with expires option equal to 30 mins', function() {
+      this.tm.generateTransaction('appState', 'state', 'nonce', null);
+      expect(Storage.prototype.setItem.calledOnce).to.be(true);
+      expect(typeof Storage.prototype.setItem.lastCall.args[2]).to.be('object');
+      expect(Storage.prototype.setItem.lastCall.args[2]).to.be.eql({ expires: times.MINUTES_30 });
     });
   });
   context('getStoredTransaction', function() {


### PR DESCRIPTION
Passed `expires` option does not override the default value.
I'd like to ask is it okay to store nonce for 30 mins? IMO, a very short time around 5 mins is enough.