### PR TITLE
Fix different id_token payload casing between authorize and popup.authorize

### DIFF
--- a/example/callback_popup.html
+++ b/example/callback_popup.html
@@ -1,20 +1,18 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <script src="/auth0.js"></script>
+    <script type="text/javascript">
+      var auth0 = new auth0.WebAuth({
+        domain: 'brucke.auth0.com',
+        redirectUri: 'http://localhost:3000/example',
+        clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
+        popupOrigin: 'http://localhost:3000'
+      });
 
-<head>
-  <script src="/auth0.js"></script>
-  <script type="text/javascript">
-    var auth0 = new auth0.WebAuth({
-      domain: 'brucke.auth0.com',
-      redirectUri: 'https://localhost:3000/example',
-      clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
-      popupOrigin: 'https://localhost:3000'
-    });
+      auth0.popup.callback();
+    </script>
+  </head>
 
-    auth0.popup.callback();
-  </script>
-</head>
-
-<body></body>
-
+  <body></body>
 </html>

--- a/src/helper/object.js
+++ b/src/helper/object.js
@@ -103,16 +103,21 @@ function toSnakeCase(object, exceptions) {
   }, {});
 }
 
-function toCamelCase(object, exceptions) {
+function toCamelCase(object, exceptions, options) {
   if (typeof object !== 'object' || assert.isArray(object) || object === null) {
     return object;
   }
 
   exceptions = exceptions || [];
-
+  options = options || {};
   return Object.keys(object).reduce(function(p, key) {
     var newKey = exceptions.indexOf(key) === -1 ? snakeToCamel(key) : key;
-    p[newKey] = toCamelCase(object[key]);
+
+    p[newKey] = toCamelCase(object[newKey] || object[key], [], options);
+
+    if (options.keepOriginal) {
+      p[key] = toCamelCase(object[key], [], options);
+    }
     return p;
   }, {});
 }

--- a/src/helper/response-handler.js
+++ b/src/helper/response-handler.js
@@ -76,7 +76,10 @@ function wrapCallback(cb, options) {
       return cb(null, data.body || data);
     }
 
-    return cb(null, objectHelper.toCamelCase(data.body || data));
+    return cb(
+      null,
+      objectHelper.toCamelCase(data.body || data, [], { keepOriginal: options.keepOriginalCasing })
+    );
   };
 }
 

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -203,7 +203,7 @@ Popup.prototype.authorize = function(options, cb) {
 
   popup = this.getPopupHandler(options);
 
-  return popup.load(url, relayUrl, popOpts, responseHandler(cb));
+  return popup.load(url, relayUrl, popOpts, responseHandler(cb, { keepOriginalCasing: true }));
 };
 
 /**

--- a/test/helper/object.test.js
+++ b/test/helper/object.test.js
@@ -452,22 +452,6 @@ describe('helpers', function() {
 
       var newObject = objectHelper.toCamelCase(object);
 
-      expect(object).to.eql({
-        attr_name_1: 'attribute_1',
-        attr_name_22: 'attribute_2',
-        attr__name_3: 'attribute_3',
-        attr_null: null,
-        arr_att: ['one', 'two'],
-        some_obj: {
-          obj_att_1: 'asdf',
-          obj_att_2: '1234',
-          inner_array_att: ['one', 'two']
-        }
-      });
-
-      expect(newObject.arrAtt).to.be.an('array');
-      expect(newObject.someObj.innerArrayAtt).to.be.an('array');
-
       expect(newObject).to.eql({
         attrName1: 'attribute_1',
         attrName22: 'attribute_2',
@@ -514,6 +498,61 @@ describe('helpers', function() {
         attr_name_22: 'attribute_2',
         attrName3: 'attribute_3'
       });
+    });
+
+    it('should keep original property as well', function() {
+      var object = {
+        attr_name_1: 'attribute_1',
+        attr_name_22: 'attribute_2',
+        attr__name_3: 'attribute_3',
+        attr_null: null,
+        arr_att: ['one', 'two'],
+        some_obj: {
+          obj_att_1: 'asdf',
+          obj_att_2: '1234',
+          inner_array_att: ['one', 'two']
+        }
+      };
+
+      var newObject = objectHelper.toCamelCase(object, [], { keepOriginal: true });
+
+      expect(newObject).to.eql({
+        attrName1: 'attribute_1',
+        attr_name_1: 'attribute_1',
+        attrName22: 'attribute_2',
+        attr_name_22: 'attribute_2',
+        attrName3: 'attribute_3',
+        attr__name_3: 'attribute_3',
+        attrNull: null,
+        attr_null: null,
+        arrAtt: ['one', 'two'],
+        arr_att: ['one', 'two'],
+        someObj: {
+          objAtt1: 'asdf',
+          obj_att_1: 'asdf',
+          objAtt2: '1234',
+          obj_att_2: '1234',
+          innerArrayAtt: ['one', 'two'],
+          inner_array_att: ['one', 'two']
+        },
+        some_obj: {
+          objAtt1: 'asdf',
+          obj_att_1: 'asdf',
+          objAtt2: '1234',
+          obj_att_2: '1234',
+          innerArrayAtt: ['one', 'two'],
+          inner_array_att: ['one', 'two']
+        }
+      });
+    });
+
+    it('do not change a property if it already exists in the object', function() {
+      var object = { attrName1: 'attr1', attr_name_1: 'attr_1' };
+      var object2 = { attr_name_1: 'attr_1', attrName1: 'attr1' };
+      var newObject = objectHelper.toCamelCase(object, [], { keepOriginal: true });
+      var newObject2 = objectHelper.toCamelCase(object2, [], { keepOriginal: true });
+      expect(newObject).to.eql({ attrName1: 'attr1', attr_name_1: 'attr_1' });
+      expect(newObject2).to.eql({ attr_name_1: 'attr_1', attrName1: 'attr1' });
     });
   });
   describe('getOriginFromUrl', function() {

--- a/test/helper/response-handler.test.js
+++ b/test/helper/response-handler.test.js
@@ -180,4 +180,24 @@ describe('helpers responseHandler', function() {
       done();
     })(null, assert_data);
   });
+
+  it('should return the data respecting the `keepOriginalCasing` option', function(done) {
+    var assert_data = {
+      body: {
+        the_attr: 'attr'
+      }
+    };
+
+    responseHandler(
+      function(err, data) {
+        expect(err).to.be(null);
+        expect(data).to.eql({
+          the_attr: 'attr',
+          theAttr: 'attr'
+        });
+        done();
+      },
+      { keepOriginalCasing: true }
+    )(null, assert_data);
+  });
 });

--- a/test/web-auth/extensibility.test.js
+++ b/test/web-auth/extensibility.test.js
@@ -111,6 +111,7 @@ describe('auth0.WebAuth extensibility', function() {
       this.webAuth.popup.authorize({ owp: true, scope: 'openid' }, function(err, data) {
         expect(err).to.be(null);
         expect(data).to.eql({
+          email_verified: false,
           emailVerified: false,
           email: 'me@example.com'
         });

--- a/test/web-auth/popup.test.js
+++ b/test/web-auth/popup.test.js
@@ -180,6 +180,7 @@ describe('auth0.WebAuth.popup', function() {
           expect(err).to.be(null);
           expect(data).to.eql({
             emailVerified: false,
+            email_verified: false,
             email: 'me@example.com'
           });
           done();


### PR DESCRIPTION
fix https://github.com/auth0/auth0.js/issues/836

### Changes

- Added new option to the `toCamelCase` helper function to keep the original values when converting to camel case
- Used this new option when calling `popup.authorize`

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/auth0.js/issues/836

### Testing

[x] This change adds unit test coverage

[ ] This change adds integration test coverage

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
