### PR TITLE
Accept left & top `popupOptions`

### DIFF
--- a/src/helper/popup-handler.js
+++ b/src/helper/popup-handler.js
@@ -28,10 +28,10 @@ PopupHandler.prototype.calculatePosition = function(options) {
       ? _window.outerHeight
       : _window.document.body.clientHeight;
 
-  var left = (outerWidth - width) / 2;
-  var top = (outerHeight - height) / 2;
+  var left = options.left || screenX + (outerWidth - width) / 2;
+  var top = options.top || screenY + (outerHeight - height) / 2;
 
-  return { width: width, height: height, left: screenX + left, top: screenY + top };
+  return { width: width, height: height, left: left, top: top };
 };
 
 PopupHandler.prototype.preload = function(options) {

--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -188,7 +188,12 @@ Popup.prototype.authorize = function(options, cb) {
   }
 
   if (options.popupOptions) {
-    popOpts.popupOptions = objectHelper.pick(options.popupOptions, ['width', 'height']);
+    popOpts.popupOptions = objectHelper.pick(options.popupOptions, [
+      'width',
+      'height',
+      'top',
+      'left'
+    ]);
   }
 
   if (pluginHandler) {


### PR DESCRIPTION
### Changes

This PR allows `left` & `top` values to be passed into `webAuth.popup.authorize`; if they are present they will override the default positioning logic.

### References

Suggested via [PR comments in #383](https://github.com/auth0/auth0.js/pull/383#issuecomment-487400784) between myself and @luisrudge

### Testing

1) Call `webAuth.popup.authorize()`; it should open in the center as usual.
2) Call `webAuth.popup.authorize({ popupOptions: { left: 0, top: 0 } })`; it should open in the top left.

[ ] This change adds unit test coverage
[ ] This change adds integration test coverage

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
