### PR TITLE
Fix appState warning

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -152,7 +152,8 @@ Authentication.prototype.buildAuthorizeUrl = function(options) {
     'popupOptions',
     'domain',
     'tenant',
-    'timeout'
+    'timeout',
+    'appState'
   ]);
   params = objectHelper.toSnakeCase(params, ['auth0Client']);
   params = parametersWhitelist.oauthAuthorizeParams(this.warn, params);

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -76,7 +76,9 @@ describe('auth0.authentication', function() {
       });
     });
 
-    ['username', 'popupOptions', 'domain', 'tenant', 'timeout'].forEach(function(param) {
+    ['username', 'popupOptions', 'domain', 'tenant', 'timeout', 'appState'].forEach(function(
+      param
+    ) {
       it('should remove parameter: ' + param, function() {
         var options = {};
         options[param] = 'foobar';


### PR DESCRIPTION
fix https://github.com/auth0/auth0.js/issues/919

### Changes

Removes the `appState` param from the url sent to the /authorize endpoint