### PR TITLE
Fix nonce error when id_token doesn't have a nonce

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -294,7 +294,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(options, parsedHash,
     if (decodedToken.header.alg !== 'HS256') {
       return callback(validationError);
     }
-    if (decodedToken.payload.nonce !== transactionNonce) {
+    if ((decodedToken.payload.nonce || null) !== transactionNonce) {
       return callback({
         error: 'invalid_token',
         errorDescription: 'Nonce does not match.'

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -1247,6 +1247,53 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
+      it.only('should not throw an error when the payload.nonce is undefined and transactionNonce is null', function(done) {
+        TransactionManager.prototype.getStoredTransaction.restore();
+        stub(TransactionManager.prototype, 'getStoredTransaction', function() {
+          return {
+            nonce: null,
+            state: 'foo'
+          };
+        });
+        var webAuth = new WebAuth({
+          domain: 'auth0-tests-lock.auth0.com',
+          redirectUri: 'http://example.com/callback',
+          clientID: 'ixeOHFhD7NSPxEQK6CFcswjUsa5YkcXS',
+          responseType: 'id_token',
+          __disableExpirationCheck: true
+        });
+        stub(webAuth.client, 'userInfo', function(accessToken, cb) {
+          expect(accessToken).to.be('VjubIMBmpgQ2W2');
+          cb(null, { from: 'userinfo' });
+        });
+        stub(IdTokenVerifier.prototype, 'verify', function(_, __, cb) {
+          cb({ error: true });
+        });
+
+        //nonce: undefined
+        webAuth.parseHash(
+          {
+            hash:
+              '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjM3ODMsImV4cCI6MTU5MzE5OTc4MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.Hoq1Go3McuHgSMg9rWVxQsEenoDWYi5MEumc32Ah9CQ&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
+          },
+          function(err, data) {
+            expect(err).to.be(null);
+            expect(data).to.be.eql({
+              accessToken: 'VjubIMBmpgQ2W2',
+              idToken:
+                'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjM3ODMsImV4cCI6MTU5MzE5OTc4MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.Hoq1Go3McuHgSMg9rWVxQsEenoDWYi5MEumc32Ah9CQ',
+              idTokenPayload: { from: 'userinfo' },
+              appState: null,
+              refreshToken: 'kajshdgfkasdjhgfas',
+              state: 'foo',
+              expiresIn: null,
+              tokenType: 'Bearer',
+              scope: null
+            });
+            done();
+          }
+        );
+      });
       it('should still throw an error with an invalid nonce', function(done) {
         var webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',
@@ -1274,40 +1321,7 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
-      it('should not throw a nonce error when the payload.nonce is undefined and transactionNonce is null', function(done) {
-        TransactionManager.prototype.getStoredTransaction.restore();
-        stub(TransactionManager.prototype, 'getStoredTransaction', function() {
-          return {
-            nonce: null,
-            state: 'foo'
-          };
-        });
-        var webAuth = new WebAuth({
-          domain: 'auth0-tests-lock.auth0.com',
-          redirectUri: 'http://example.com/callback',
-          clientID: 'ixeOHFhD7NSPxEQK6CFcswjUsa5YkcXS',
-          responseType: 'id_token',
-          __disableExpirationCheck: true
-        });
-        stub(IdTokenVerifier.prototype, 'verify', function(_, __, cb) {
-          cb({ error: true });
-        });
 
-        //nonce: undefined
-        webAuth.parseHash(
-          {
-            hash:
-              '#state=foo&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjM3ODMsImV4cCI6MTU5MzE5OTc4MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.Hoq1Go3McuHgSMg9rWVxQsEenoDWYi5MEumc32Ah9CQ&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
-          },
-          function(err, data) {
-            expect(err).not.to.be.eql({
-              error: 'invalid_token',
-              errorDescription: 'Nonce does not match.'
-            });
-            done();
-          }
-        );
-      });
       it('should still throw an error with an invalid state', function(done) {
         var webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -1247,7 +1247,7 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
-      it.only('should not throw an error when the payload.nonce is undefined and transactionNonce is null', function(done) {
+      it('should not throw an error when the payload.nonce is undefined and transactionNonce is null', function(done) {
         TransactionManager.prototype.getStoredTransaction.restore();
         stub(TransactionManager.prototype, 'getStoredTransaction', function() {
           return {


### PR DESCRIPTION
fix https://github.com/auth0/auth0.js/issues/953

### Changes

If the payload of a decoded id_token had no `nonce`, the code would always throw a nonce error because of a `undefined !== null` check, which always evaluates to false.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

[x] This change adds unit test coverage

[ ] This change adds integration test coverage
