### PR TITLE
use --trace when uploading to the cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ci:coverage": "codecov",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",
-    "publish:cdn": "ccu",
+    "publish:cdn": "ccu --trace",
     "release": "scripts/release.sh",
     "jsdocs": "jsdoc --configure .jsdoc.json --verbose",
     "precommit": "lint-staged"


### PR DESCRIPTION
### Description

This will make the logs in our build server to display more information about the cdn upload