### PR TITLE
Document `appState` option usage. Closes #1002

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -261,6 +261,7 @@ Authentication.prototype.buildLogoutUrl = function(options) {
  * @param {Number} [result.expiresIn] number of seconds until the access token expires
  * @param {String} [result.idToken] token that identifies the user
  * @param {String} [result.refreshToken] token that can be used to get new access tokens from Auth0. Note that not all Auth0 Applications can request them or the resource server might not allow them.
+ * @param {Object} [result.appState] values that you receive back on the authentication response
  */
 
 /**

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -645,6 +645,7 @@ WebAuth.prototype.signup = function(options, cb) {
  * @param {String} [options.nonce] value used to mitigate replay attacks when using Implicit Grant. {@link https://auth0.com/docs/api-auth/tutorials/nonce}
  * @param {String} [options.scope] scopes to be requested during Auth. e.g. `openid email`
  * @param {String} [options.audience] identifier of the resource server who will consume the access token issued after Auth
+ * @param {Object} [options.appState] any values that you want back on the authentication response
  * @see {@link https://auth0.com/docs/api/authentication#authorize-client}
  */
 WebAuth.prototype.authorize = function(options) {


### PR DESCRIPTION
Thanks!

### Changes

This is a minor change that adds documentation references for `appState` option.

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
