### PR TITLE
Add missing JSDoc entry for 'username' signup option. Closes #1005

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -24,6 +24,7 @@ function DBConnection(request, options) {
  * @param {Object} options
  * @param {String} options.email user email address
  * @param {String} options.password user password
+ * @param {String} [options.username] user desired username. Required if you use a database connection and you have enabled `Requires Username`
  * @param {String} options.connection name of the connection where the user will be created
  * @param {Object} [options.userMetadata] additional signup attributes used for creating the user. Will be stored in `user_metadata`
  * @param {signUpCallback} cb


### PR DESCRIPTION
This is a minor correction, aligns JSDoc with online documentation.

Thanks!