### PR TITLE
fix/passwordless-authparams-priority

### DIFF
--- a/src/authentication/passwordless-authentication.js
+++ b/src/authentication/passwordless-authentication.js
@@ -133,17 +133,19 @@ PasswordlessAuthentication.prototype.start = function(options, cb) {
 
   if (body.scope) {
     body.authParams = body.authParams || {};
-    body.authParams.scope = body.scope;
+    body.authParams.scope = body.authParams.scope || body.scope;
   }
 
   if (body.redirectUri) {
     body.authParams = body.authParams || {};
-    body.authParams.redirect_uri = body.redirectUri;
+    body.authParams.redirect_uri =
+      body.authParams.redirectUri || body.redirectUri;
   }
 
   if (body.responseType) {
     body.authParams = body.authParams || {};
-    body.authParams.response_type = body.responseType;
+    body.authParams.response_type =
+      body.authParams.responseType || body.responseType;
   }
 
   delete body.redirectUri;

--- a/test/authentication/passwordless.test.js
+++ b/test/authentication/passwordless.test.js
@@ -174,7 +174,8 @@ describe('auth0.authentication', function() {
         clientID: '...',
         redirectUri: 'http://page.com/callback',
         responseType: 'code',
-        _sendTelemetry: false
+        _sendTelemetry: false,
+        scope: ''
       });
     });
 
@@ -222,6 +223,14 @@ describe('auth0.authentication', function() {
     });
 
     it('should call passwordless start with authParams', function(done) {
+      var auth0 = new Authentication({
+        domain: 'me.auth0.com',
+        clientID: '...',
+        redirectUri: 'will be overridden',
+        responseType: 'code',
+        _sendTelemetry: false,
+        scope: 'will be overridden'
+      });
       sinon.stub(request, 'post').callsFake(function(url) {
         expect(url).to.be('https://me.auth0.com/passwordless/start');
         return new RequestMock({

--- a/test/authentication/passwordless.test.js
+++ b/test/authentication/passwordless.test.js
@@ -232,7 +232,7 @@ describe('auth0.authentication', function() {
             send: 'code',
             authParams: {
               scope: 'openid email',
-              redirect_uri: 'http://page.com/callback',
+              redirect_uri: 'http://page.com/othercallback',
               response_type: 'code'
             }
           },
@@ -252,7 +252,10 @@ describe('auth0.authentication', function() {
           connection: 'the_connection',
           email: 'me@example.com',
           send: 'code',
-          scope: 'openid email'
+          scope: 'openid email',
+          authParams: {
+            redirectUri: 'http://page.com/othercallback'
+          }
         },
         function(err, data) {
           expect(err).to.be(null);

--- a/test/authentication/passwordless.test.js
+++ b/test/authentication/passwordless.test.js
@@ -233,7 +233,8 @@ describe('auth0.authentication', function() {
             authParams: {
               scope: 'openid email',
               redirect_uri: 'http://page.com/othercallback',
-              response_type: 'code'
+              response_type: 'token',
+              protocol: 'wsfed'
             }
           },
           headers: {
@@ -252,9 +253,11 @@ describe('auth0.authentication', function() {
           connection: 'the_connection',
           email: 'me@example.com',
           send: 'code',
-          scope: 'openid email',
           authParams: {
-            redirectUri: 'http://page.com/othercallback'
+            redirectUri: 'http://page.com/othercallback',
+            protocol: 'wsfed',
+            responseType: 'token',
+            scope: 'openid email'
           }
         },
         function(err, data) {


### PR DESCRIPTION
### Changes

- Updated authParams priority for the `WebAuth` `passwordlessStart` method
- Updated relevant test

### References

Closes issue #1018 

### Testing

- [x] This change adds unit test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors