### PR TITLE
also support ionic:// protocol (for iOS ionic web view)

### DIFF
--- a/src/helper/object.js
+++ b/src/helper/object.js
@@ -124,7 +124,7 @@ function toCamelCase(object, exceptions, options) {
 
 function getLocationFromUrl(href) {
   var match = href.match(
-    /^(https?:|file:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
+    /^(https?:|file:|ionic:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
   );
   return (
     match && {


### PR DESCRIPTION
### Changes

I am using auth0 with cordova. In the cordova app, I am using [`cordova-plugin-ionic-webview`](https://github.com/ionic-team/cordova-plugin-ionic-webview). This plugin serves files on iOS over `ionic://localhost`. It is [not possible](https://github.com/ionic-team/cordova-plugin-ionic-webview#iosscheme) to change the "protocol" into `http(s)://` or `file://`.

Unfortunately, using cross origin authentication in popupMode fails on iOS since the url parser assumes that the protocol is either `http(s)://` or `file://`. When changing the hardcoded regex like in the pull request, everything works as expected. Please consider merging it in for other cordova users.
