### PR TITLE
Bugfix for WebExtension

### DIFF
--- a/src/helper/object.js
+++ b/src/helper/object.js
@@ -124,7 +124,7 @@ function toCamelCase(object, exceptions, options) {
 
 function getLocationFromUrl(href) {
   var match = href.match(
-    /^(https?:|file:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
+    /^(https?:|file:|chrome-extension:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/
   );
   return (
     match && {


### PR DESCRIPTION
Can you approve this change to handle WebExtensions, please? The auth0-lock and auth0-js projects are affected by this change. I used auth0-chrome which is supposed to work for the extensions, but this library is not adapted and poses problems of ergonomics.
Thanks in advance.