### PR TITLE
[CAUTH-239] Add getChallenge method

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -547,6 +547,28 @@ Authentication.prototype.userInfo = function(accessToken, cb) {
 };
 
 /**
+ * Makes a call to the `/usernamepassword/challenge` endpoint
+ * and returns the challenge (captcha) if necessary.
+ *
+ * @method getChallenge
+ * @param {callback} cb
+ */
+Authentication.prototype.getChallenge = function(cb) {
+  assert.check(cb, { type: 'function', message: 'cb parameter is not valid' });
+
+  if (!this.baseOptions.state) {
+    return cb();
+  }
+
+  var url = urljoin(this.baseOptions.rootUrl, 'usernamepassword', 'challenge');
+
+  return this.request
+    .post(url)
+    .send({ state: this.baseOptions.state })
+    .end(responseHandler(cb, { ignoreCasing: true }));
+};
+
+/**
  * @callback delegationCallback
  * @param {Error} [err] error returned by Auth0 with the reason why the delegation failed
  * @param {Object} [result] result of the delegation request. The payload depends on what ai type was used


### PR DESCRIPTION
### Changes

Add a method to create and retrieve a challenge (aka captcha).

### References

https://auth0team.atlassian.net/browse/CAUTH-239

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
