### PR TITLE
Set the default token validation leeway to 60 sec

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -436,7 +436,7 @@ WebAuth.prototype.validateToken = function(token, nonce, cb) {
     issuer: this.baseOptions.token_issuer,
     jwksURI: this.baseOptions.jwksURI,
     audience: this.baseOptions.clientID,
-    leeway: this.baseOptions.leeway || 0,
+    leeway: this.baseOptions.leeway || 60,
     maxAge: this.baseOptions.maxAge,
     __clock: this.baseOptions.__clock || defaultClock
   });

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -2863,6 +2863,47 @@ describe('auth0.WebAuth', function() {
   });
 
   context('validateToken', function() {
+    it('should send through a default leeway', function(done) {
+      var idTokenVerifierMock = function(opts) {
+        expect(opts.leeway).to.be(60);
+        done();
+      };
+
+      var { default: ProxiedWebAuth } = proxyquire('../../src/web-auth', {
+        'idtoken-verifier': idTokenVerifierMock
+      });
+
+      var webAuth = new ProxiedWebAuth({
+        domain: 'brucke.auth0.com',
+        redirectUri: 'http://example.com/callback',
+        clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
+        responseType: 'token id_token'
+      });
+
+      webAuth.validateToken('token', 'nonce', function() {});
+    });
+
+    it('should accept a specified leeway', function(done) {
+      var idTokenVerifierMock = function(opts) {
+        expect(opts.leeway).to.be(25);
+        done();
+      };
+
+      var { default: ProxiedWebAuth } = proxyquire('../../src/web-auth', {
+        'idtoken-verifier': idTokenVerifierMock
+      });
+
+      var webAuth = new ProxiedWebAuth({
+        domain: 'brucke.auth0.com',
+        redirectUri: 'http://example.com/callback',
+        clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
+        responseType: 'token id_token',
+        leeway: 25
+      });
+
+      webAuth.validateToken('token', 'nonce', function() {});
+    });
+
     it('should use undefined jwksURI, allowing it to be overwritten later', function(done) {
       var idTokenVerifierMock = function(opts) {
         expect(opts.jwksURI).to.be(undefined);
@@ -2880,6 +2921,7 @@ describe('auth0.WebAuth', function() {
 
       webAuth.validateToken('token', 'nonce', function() {});
     });
+
     it('should use correct jwksURI when overriden', function(done) {
       var idTokenVerifierMock = function(opts) {
         expect(opts.jwksURI).to.be('jwks_uri');


### PR DESCRIPTION
### Changes

This sets the default leeway for validating tokens to 60 seconds, in alignment with `idtoken-verifier`.

### Testing

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
