### PR TITLE
Add jsdoc for the OIDC compliance introduced props

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -32,6 +32,8 @@ function defaultClock() {
  * @param {String} [options.responseMode] how the Auth response is encoded and redirected back to the client. Supported values are `query`, `fragment` and `form_post`. The `query` value is only supported when `responseType` is `code`. {@link https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#ResponseModes}
  * @param {String} [options.scope] scopes to be requested during Auth. e.g. `openid email`
  * @param {String} [options.audience] identifier of the resource server who will consume the access token issued after Auth
+ * @param {Number} [options.maxAge] the allowable elapsed time in seconds since the last time user was authenticated. By default there's no limit
+ * @param {Number} [options.leeway] the clock-skew or leeway value in seconds to use in the ID Token verification. Defaults to 60 seconds
  * @param {Array} [options.plugins]
  * @param {Number} [options._timesToRetryFailedRequests] Number of times to retry a failed request, according to {@link https://github.com/visionmedia/superagent/blob/master/lib/request-base.js}
  * @see {@link https://auth0.com/docs/api/authentication}


### PR DESCRIPTION
### Changes

While the `leeway` and `maxAge` properties of the WebAuth object options where public, they were not documented properly and someone might have missed them.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
