### PR TITLE
[SDK-1405] Added support for new 'blocked_reasons' error type

### DIFF
--- a/src/helper/response-handler.js
+++ b/src/helper/response-handler.js
@@ -54,17 +54,14 @@ function wrapCallback(cb, options) {
         err.details ||
         err.err ||
         null;
+
       if (options.forceLegacyError) {
         errObj.error = errObj.code;
         errObj.error_description = errObj.description;
       }
 
-      if (
-        errObj.code === 'blocked_user' &&
-        err.error_codes &&
-        err.error_details
-      ) {
-        errObj.blockedUser = {
+      if (err.error_codes && err.error_details) {
+        errObj.errorDetails = {
           codes: err.error_codes,
           details: err.error_details
         };

--- a/src/helper/response-handler.js
+++ b/src/helper/response-handler.js
@@ -45,6 +45,7 @@ function wrapCallback(cb, options) {
 
       errObj.code =
         err.code || err.error || err.error_code || err.status || null;
+
       errObj.description =
         err.errorDescription ||
         err.error_description ||
@@ -56,6 +57,17 @@ function wrapCallback(cb, options) {
       if (options.forceLegacyError) {
         errObj.error = errObj.code;
         errObj.error_description = errObj.description;
+      }
+
+      if (
+        errObj.code === 'blocked_user' &&
+        err.error_codes &&
+        err.error_details
+      ) {
+        errObj.blockedUser = {
+          codes: err.error_codes,
+          details: err.error_details
+        };
       }
 
       if (err.name) {

--- a/test/helper/response-handler.test.js
+++ b/test/helper/response-handler.test.js
@@ -150,6 +150,47 @@ describe('helpers responseHandler', function() {
     })(assert_err, null);
   });
 
+  it('should return normalized block codes', function(done) {
+    var assert_err = {};
+    assert_err.response = {};
+    assert_err.response.body = {
+      code: 'blocked_user',
+      error: 'Blocked user.',
+      error_codes: ['reason-1', 'reason-2'],
+      error_details: {
+        'reason-1': {
+          timestamp: 123
+        },
+        'reason-2': {
+          timestamp: 456
+        }
+      }
+    };
+
+    responseHandler(function(err, data) {
+      expect(data).to.be(undefined);
+
+      expect(err).to.eql({
+        original: assert_err,
+        code: 'blocked_user',
+        description: 'Blocked user.',
+        blockedUser: {
+          codes: ['reason-1', 'reason-2'],
+          details: {
+            'reason-1': {
+              timestamp: 123
+            },
+            'reason-2': {
+              timestamp: 456
+            }
+          }
+        }
+      });
+
+      done();
+    })(assert_err, null);
+  });
+
   it('should return the data', function(done) {
     var assert_data = {
       body: {

--- a/test/helper/response-handler.test.js
+++ b/test/helper/response-handler.test.js
@@ -150,7 +150,7 @@ describe('helpers responseHandler', function() {
     })(assert_err, null);
   });
 
-  it('should return normalized block codes', function(done) {
+  it('should return normalized error codes and details', function(done) {
     var assert_err = {};
     assert_err.response = {};
     assert_err.response.body = {
@@ -174,7 +174,7 @@ describe('helpers responseHandler', function() {
         original: assert_err,
         code: 'blocked_user',
         description: 'Blocked user.',
-        blockedUser: {
+        errorDetails: {
           codes: ['reason-1', 'reason-2'],
           details: {
             'reason-1': {


### PR DESCRIPTION
### Changes

This PR adds support for new "blocked_reasons" error type, which includes more detail behind why a user has been blocked.

The details are surfaced in the error object as follows:

```js
{
  code: 'blocked_user',
  description: 'Blocked user.',
  errorDetails: {
    codes: [ 'reason-1', 'reason-2' ],
    details: {
      'reason-1': {
        timestamp: 123786498
      },
      'reason-2': {
        timestamp: 127836389
      }
    }
  } 
}
```

### References

Support for this was generated from an internal service desk ticket.

### Testing

- [X] This change adds unit test coverage
- [X] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
