### PR TITLE
Fix unit tests by stubbing RSA verification

### DIFF
--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -292,17 +292,35 @@ describe('auth0.WebAuth', function() {
         appState: null
       });
       sinon.spy(SSODataStorage.prototype, 'set');
+
       sinon
         .stub(IdTokenVerifier.prototype, 'validateAccessToken')
         .callsFake(function(at, alg, atHash, cb) {
           cb(null);
         });
+
+      sinon
+        .stub(IdTokenVerifier.prototype, 'getRsaVerifier')
+        .callsFake(function(iss, kid, cb) {
+          cb(null, {
+            verify: function() {
+              return true;
+            }
+          });
+        });
     });
+
     afterEach(function() {
       SSODataStorage.prototype.set.restore();
+
       if (IdTokenVerifier.prototype.validateAccessToken.restore) {
         IdTokenVerifier.prototype.validateAccessToken.restore();
       }
+
+      if (IdTokenVerifier.prototype.getRsaVerifier.restore) {
+        IdTokenVerifier.prototype.getRsaVerifier.restore();
+      }
+
       if (WebAuth.prototype.validateToken.restore) {
         WebAuth.prototype.validateToken.restore();
       }
@@ -360,7 +378,12 @@ describe('auth0.WebAuth', function() {
           nonce: 'lFCnI8.crRTdHfdo5k.zMXfR31856gKz'
         },
         function(err, data) {
+          if (err) {
+            return done(err);
+          }
+
           expect(err).to.be(null);
+
           expect(data).to.be.eql({
             accessToken: null,
             idToken:
@@ -388,6 +411,7 @@ describe('auth0.WebAuth', function() {
             tokenType: 'Bearer',
             scope: null
           });
+
           done();
         }
       ); // eslint-disable-line


### PR DESCRIPTION
### Changes

Currently, the unit tests use [`idtoken-verifier`](https://github.com/auth0/idtoken-verifier) to verify ID tokens, including downloading the JWKS document to verify the RS256 signature.

This PR stubs that call out to always return `true` for RSA verification (the tests assumed true anyway), but it does make the tests more robust and unaffected by signing key changes on the server.

### References

Instigated by [this failing test suite](https://app.circleci.com/pipelines/github/auth0/auth0.js/68/workflows/5dadd88c-3720-4817-8182-2cae24f3d813/jobs/1576).

### Testing

No test coverage added, just changes to setup/teardown for the `parseHash` tests.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
