### PR TITLE
Add screen_hint to allowed parameters

### DIFF
--- a/src/helper/parameters-whitelist.js
+++ b/src/helper/parameters-whitelist.js
@@ -50,6 +50,7 @@ var authorizeParams = [
   'nonce',
   'display',
   'prompt',
+  'screen_hint',
   'max_age',
   'ui_locales',
   'claims_locales',


### PR DESCRIPTION
### Changes

This PR adds support for new "screen_hint" option, which allows showing the signup page instead of the signin page; fixes #1092.

### References

Feature description: https://auth0.com/docs/universal-login/new#signup.
Documentation needs to be updated: https://auth0.com/docs/libraries/auth0js/v9#webauth-authorize-.

### Testing

The typical usage looks as follows:
```
webauth.authorize({screen_hint: 'signup'})
```
Sign Up tab should be displayed on the Universal Login Page.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors