### PR TITLE
[CAUTH-423]  Add login state if available to the sign-up request

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -48,7 +48,7 @@ DBConnection.prototype.signup = function(options, cb) {
 
   url = urljoin(this.baseOptions.rootUrl, 'dbconnections', 'signup');
 
-  body = objectHelper.merge(this.baseOptions, ['clientID']).with(options);
+  body = objectHelper.merge(this.baseOptions, ['clientID', 'state']).with(options);
 
   metadata = body.user_metadata || body.userMetadata;
 

--- a/test/authentication/db-connection.test.js
+++ b/test/authentication/db-connection.test.js
@@ -15,7 +15,8 @@ describe('auth0.authentication', function() {
         domain: 'me.auth0.com',
         clientID: '...',
         redirectUri: 'http://page.com/callback',
-        responseType: 'code'
+        responseType: 'code',
+        state: 'state-xyz'
       });
     });
 
@@ -80,6 +81,7 @@ describe('auth0.authentication', function() {
           return new RequestMock({
             body: {
               client_id: '...',
+              state: 'state-xyz',
               email: 'the email',
               password: 'the password',
               connection: 'the_connection',
@@ -129,6 +131,7 @@ describe('auth0.authentication', function() {
           return new RequestMock({
             body: {
               client_id: '...',
+              state: 'state-xyz',
               email: 'the email',
               password: 'the password',
               connection: 'the_connection',


### PR DESCRIPTION
### Changes

Include the login `state` as a parameter in the sign-up call if available. This affects only in the classic Hosted Login Page and is optional for most of the cases. 

### References

https://auth0team.atlassian.net/browse/CAUTH-423

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
