### PR TITLE
[CAUTH-551] add render captcha method

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -118,10 +118,17 @@ function render(auth0Client, element, options, callback) {
     });
   }
 
+  function getValue() {
+    var captchaInput = element.querySelector('input[name="captcha"]');
+    if (!captchaInput) { return; }
+    return captchaInput.value;
+  }
+
   load(callback);
 
   return {
-    reload: load
+    reload: load,
+    getValue: getValue
   };
 }
 

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -1,0 +1,128 @@
+// eslint-disable-next-line no-unused-vars
+import Authentication from '../authentication';
+import object from '../helper/object';
+
+var noop = function () { };
+
+var defaults = {
+  lang: 'en',
+  templates: {
+    'auth0': function (challenge) {
+      var message = challenge.type === 'code' ?
+        'Enter the code shown above' :
+        'Solve the formula shown above';
+      return '<div class="captcha-challenge">\n' +
+        '  <img src="' + challenge.image + '" />\n' +
+        '  <button type="button" class="captcha-reload">↺</button>\n' +
+        '</div>\n' +
+        '<input type="text" name="captcha"\n' +
+        '  class="form-control captcha-control"\n' +
+        '  placeholder="' + message + '" />';
+    }
+    ,
+    'recaptcha_v2': function () {
+      return '<div class="recaptcha" ></div><input type="hidden" name="captcha" />';
+    }
+    ,
+    'error': function () {
+      return '<div class="error" style="color: red;">Error getting the bot detection challenge. Please contact the system administrator.</div>'
+    }
+  }
+};
+
+function handleAuth0Provider(element, options, challenge, load) {
+  element.innerHTML = options.templates[challenge.provider](challenge);
+  element.querySelector('.captcha-reload').addEventListener('click', function (e) {
+    e.preventDefault();
+    load();
+  });
+}
+
+function injectRecaptchaScript(element, lang, callback) {
+  var callbackName = 'recaptchaCallback_' + Math.floor(Math.random() * 1000001);
+  window[callbackName] = function () {
+    delete window[callbackName];
+    callback();
+  };
+  var script = window.document.createElement('script');
+  script.src = 'https://www.google.com/recaptcha/api.js?hl=' + lang + '&onload=' + callbackName;
+  script.async = true;
+  window.document.body.appendChild(script);
+}
+
+function handleRecaptchaProvider(element, options, challenge) {
+  var widgetId = element.hasAttribute('data-wid') && element.getAttribute('data-wid');
+
+  function setValue(value) {
+    var input = element.querySelector('input[name="captcha"]');
+    input.value = value || '';
+  }
+
+  if (widgetId) {
+    setValue();
+    window.grecaptcha.reset(widgetId);
+    return;
+  }
+
+  element.innerHTML = options.templates[challenge.provider](challenge);
+
+  var recaptchaDiv = element.querySelector('.recaptcha');
+
+  injectRecaptchaScript(element, options.lang, function () {
+    widgetId = window.grecaptcha.render(recaptchaDiv, {
+      callback: setValue,
+      'expired-callback': function () { setValue(); },
+      'error-callback': function () { setValue(); },
+      sitekey: challenge.siteKey
+    });
+    element.setAttribute('data-wid', widgetId)
+  });
+}
+
+
+/**
+ *
+ * Renders the captcha challenge in the provided element.
+ *
+ * @param {Authentication} auth0Client The challenge response from the authentication server
+ * @param {HTMLElement} element The element where the captcha needs to be rendered
+ * @param {Object} options The configuration options for the captcha
+ * @param {Object} [options.templates] An object containaing templates for each captcha provider
+ * @param {Function} [options.templates.auth0] template function receiving the challenge and returning an string
+ * @param {Function} [options.templates.recaptcha_v2] template function receiving the challenge and returning an string
+ * @param {String} [options.lang=en] the ISO code of the language for recaptcha*
+ * @param {Function} [callback] an optional callback function
+ */
+function render(auth0Client, element, options, callback) {
+  options = object.merge(defaults).with(options || {});
+
+  function load(done) {
+    done = done || noop;
+    auth0Client.getChallenge(function (err, challenge) {
+      if (err) {
+        element.innerHTML = options.templates.error(err);
+        return done(err);
+      }
+      if (!challenge.required) {
+        element.style.display = 'none';
+        element.innerHTML = '';
+        return;
+      }
+      element.style.display = '';
+      if (challenge.provider === 'auth0') {
+        handleAuth0Provider(element, options, challenge, load);
+      } else if (challenge.provider === 'recaptcha_v2') {
+        handleRecaptchaProvider(element, options, challenge);
+      }
+      done();
+    });
+  }
+
+  load(callback);
+
+  return {
+    reload: load
+  };
+}
+
+export default { render: render };

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -16,6 +16,7 @@ import SilentAuthenticationHandler from './silent-authentication-handler';
 import CrossOriginAuthentication from './cross-origin-authentication';
 import WebMessageHandler from './web-message-handler';
 import HostedPages from './hosted-pages';
+import captcha from './captcha';
 
 function defaultClock() {
   return new Date();
@@ -193,7 +194,7 @@ function WebAuth(options) {
  * @param {String} [options.responseType] type of the response used by OAuth 2.0 flow. It can be any space separated list of the values `token`, `id_token`. For this specific method, we'll only use this value to check if the hash contains the tokens requested in the responseType.
  * @param {authorizeCallback} cb
  */
-WebAuth.prototype.parseHash = function(options, cb) {
+WebAuth.prototype.parseHash = function (options, cb) {
   var parsedQs;
   var err;
 
@@ -279,7 +280,7 @@ WebAuth.prototype.parseHash = function(options, cb) {
  * @param {Object} parsedHash an object that represents the parsed hash
  * @param {authorizeCallback} cb
  */
-WebAuth.prototype.validateAuthenticationResponse = function(
+WebAuth.prototype.validateAuthenticationResponse = function (
   options,
   parsedHash,
   cb
@@ -307,7 +308,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(
 
   var appState = options.state || (transaction && transaction.appState) || null;
 
-  var callback = function(err, payload) {
+  var callback = function (err, payload) {
     if (err) {
       return cb(err);
     }
@@ -324,7 +325,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(
   if (!parsedHash.id_token) {
     return callback(null, null);
   }
-  return this.validateToken(parsedHash.id_token, transactionNonce, function(
+  return this.validateToken(parsedHash.id_token, transactionNonce, function (
     validationError,
     payload
   ) {
@@ -342,7 +343,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(
         parsedHash.access_token,
         'RS256',
         payload.at_hash,
-        function(err) {
+        function (err) {
           if (err) {
             return callback(error.invalidToken(err.message));
           }
@@ -391,7 +392,7 @@ WebAuth.prototype.validateAuthenticationResponse = function(
     }
 
     // if the alg is HS256, use the /userinfo endpoint to build the payload
-    return _this.client.userInfo(parsedHash.access_token, function(
+    return _this.client.userInfo(parsedHash.access_token, function (
       errUserInfo,
       profile
     ) {
@@ -433,7 +434,7 @@ function buildParseHashResponse(qsParams, appState, token) {
  * @param {String} nonce
  * @param {validateTokenCallback} cb
  */
-WebAuth.prototype.validateToken = function(token, nonce, cb) {
+WebAuth.prototype.validateToken = function (token, nonce, cb) {
   var verifier = new IdTokenVerifier({
     issuer: this.baseOptions.token_issuer,
     jwksURI: this.baseOptions.jwksURI,
@@ -443,7 +444,7 @@ WebAuth.prototype.validateToken = function(token, nonce, cb) {
     __clock: this.baseOptions.__clock || defaultClock
   });
 
-  verifier.verify(token, nonce, function(err, payload) {
+  verifier.verify(token, nonce, function (err, payload) {
     if (err) {
       return cb(error.invalidToken(err.message));
     }
@@ -474,7 +475,7 @@ WebAuth.prototype.validateToken = function(token, nonce, cb) {
  * @param {authorizeCallback} cb
  * @see {@link https://auth0.com/docs/api/authentication#authorize-client}
  */
-WebAuth.prototype.renewAuth = function(options, cb) {
+WebAuth.prototype.renewAuth = function (options, cb) {
   var handler;
   var usePostMessage = !!options.usePostMessage;
   var postMessageDataType = options.postMessageDataType || false;
@@ -523,7 +524,7 @@ WebAuth.prototype.renewAuth = function(options, cb) {
     timeout: timeout
   });
 
-  handler.login(usePostMessage, function(err, hash) {
+  handler.login(usePostMessage, function (err, hash) {
     if (typeof hash === 'object') {
       // hash was already parsed, so we just return it.
       // it's here to be backwards compatible and should be removed in the next major version.
@@ -548,7 +549,7 @@ WebAuth.prototype.renewAuth = function(options, cb) {
  * @param {checkSessionCallback} cb
  * @see {@link https://auth0.com/docs/libraries/auth0js/v9#using-checksession-to-acquire-new-tokens}
  */
-WebAuth.prototype.checkSession = function(options, cb) {
+WebAuth.prototype.checkSession = function (options, cb) {
   var params = objectHelper
     .merge(this.baseOptions, [
       'clientID',
@@ -608,7 +609,7 @@ WebAuth.prototype.checkSession = function(options, cb) {
  * @param {changePasswordCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#change-password}
  */
-WebAuth.prototype.changePassword = function(options, cb) {
+WebAuth.prototype.changePassword = function (options, cb) {
   return this.client.dbConnection.changePassword(options, cb);
 };
 
@@ -625,7 +626,7 @@ WebAuth.prototype.changePassword = function(options, cb) {
  * @param {Function} cb
  * @see   {@link https://auth0.com/docs/api/authentication#passwordless}
  */
-WebAuth.prototype.passwordlessStart = function(options, cb) {
+WebAuth.prototype.passwordlessStart = function (options, cb) {
   var authParams = objectHelper
     .merge(this.baseOptions, [
       'responseType',
@@ -655,7 +656,7 @@ WebAuth.prototype.passwordlessStart = function(options, cb) {
  * @param {signUpCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  */
-WebAuth.prototype.signup = function(options, cb) {
+WebAuth.prototype.signup = function (options, cb) {
   return this.client.dbConnection.signup(options, cb);
 };
 
@@ -676,7 +677,7 @@ WebAuth.prototype.signup = function(options, cb) {
  * @param {Object} [options.appState] any values that you want back on the authentication response
  * @see {@link https://auth0.com/docs/api/authentication#authorize-client}
  */
-WebAuth.prototype.authorize = function(options) {
+WebAuth.prototype.authorize = function (options) {
   var params = objectHelper
     .merge(this.baseOptions, [
       'clientID',
@@ -722,12 +723,12 @@ WebAuth.prototype.authorize = function(options) {
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  * @see   {@link https://auth0.com/docs/api-auth/grant/password}
  */
-WebAuth.prototype.signupAndAuthorize = function(options, cb) {
+WebAuth.prototype.signupAndAuthorize = function (options, cb) {
   var _this = this;
 
   return this.client.dbConnection.signup(
     objectHelper.blacklist(options, ['popupHandler']),
-    function(err) {
+    function (err) {
       if (err) {
         return cb(err);
       }
@@ -762,7 +763,7 @@ WebAuth.prototype.signupAndAuthorize = function(options, cb) {
  * @param {String} [options.realm] Realm used to authenticate the user, it can be a realm name or a database connection name
  * @param {crossOriginLoginCallback} cb Callback function called only when an authentication error, like invalid username or password, occurs. For other types of errors, there will be a redirect to the `redirectUri`.
  */
-WebAuth.prototype.login = function(options, cb) {
+WebAuth.prototype.login = function (options, cb) {
   var params = objectHelper
     .merge(this.baseOptions, [
       'clientID',
@@ -801,7 +802,7 @@ WebAuth.prototype.login = function(options, cb) {
  * @param {String} options.connection Passwordless connection to use. It can either be 'sms' or 'email'.
  * @param {crossOriginLoginCallback} cb Callback function called only when an authentication error, like invalid username or password, occurs. For other types of errors, there will be a redirect to the `redirectUri`.
  */
-WebAuth.prototype.passwordlessLogin = function(options, cb) {
+WebAuth.prototype.passwordlessLogin = function (options, cb) {
   var params = objectHelper
     .merge(this.baseOptions, [
       'clientID',
@@ -846,7 +847,7 @@ WebAuth.prototype.passwordlessLogin = function(options, cb) {
  * @method crossOriginAuthenticationCallback
  * @deprecated Use {@link crossOriginVerification} instead.
  */
-WebAuth.prototype.crossOriginAuthenticationCallback = function() {
+WebAuth.prototype.crossOriginAuthenticationCallback = function () {
   this.crossOriginVerification();
 };
 
@@ -855,7 +856,7 @@ WebAuth.prototype.crossOriginAuthenticationCallback = function() {
  *
  * @method crossOriginVerification
  */
-WebAuth.prototype.crossOriginVerification = function() {
+WebAuth.prototype.crossOriginVerification = function () {
   this.crossOriginAuthentication.callback();
 };
 
@@ -874,7 +875,7 @@ WebAuth.prototype.crossOriginVerification = function() {
  * @param {Boolean} [options.federated] tells Auth0 if it should logout the user also from the IdP.
  * @see   {@link https://auth0.com/docs/api/authentication#logout}
  */
-WebAuth.prototype.logout = function(options) {
+WebAuth.prototype.logout = function (options) {
   windowHelper.redirect(this.client.buildLogoutUrl(options));
 };
 
@@ -890,7 +891,7 @@ WebAuth.prototype.logout = function(options) {
  * @param {String} options.verificationCode the TOTP code
  * @param {Function} cb
  */
-WebAuth.prototype.passwordlessVerify = function(options, cb) {
+WebAuth.prototype.passwordlessVerify = function (options, cb) {
   var _this = this;
   var params = objectHelper
     .merge(this.baseOptions, [
@@ -919,7 +920,7 @@ WebAuth.prototype.passwordlessVerify = function(options, cb) {
   );
 
   params = this.transactionManager.process(params);
-  return this.client.passwordless.verify(params, function(err) {
+  return this.client.passwordless.verify(params, function (err) {
     if (err) {
       return cb(err);
     }
@@ -927,6 +928,23 @@ WebAuth.prototype.passwordlessVerify = function(options, cb) {
       _this.client.passwordless.buildVerifyUrl(params)
     );
   });
+};
+
+/**
+ *
+ * Renders the captcha challenge in the provided element.
+ * This function can only be used in the context of a Classic Universal Login Page.
+ *
+ * @param {HTMLElement} element The element where the captcha needs to be rendered
+ * @param {Object} options The configuration options for the captcha
+ * @param {Object} [options.templates] An object containaing templates for each captcha provider
+ * @param {Function} [options.templates.auth0] template function receiving the challenge and returning an string
+ * @param {Function} [options.templates.recaptcha_v2] template function receiving the challenge and returning an string
+ * @param {String} [options.lang=en] the ISO code of the language for recaptcha
+ * @param {Function} [callback] An optional completion callback
+ */
+WebAuth.prototype.renderCaptcha = function (element, options, callback) {
+  return captcha.render(this.client, element, options, callback);
 };
 
 export default WebAuth;

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -1,0 +1,258 @@
+import { JSDOM } from 'jsdom';
+import url from 'url';
+import sinon from 'sinon';
+import captcha from '../../src/web-auth/captcha';
+import expect from 'expect.js';
+
+describe('captcha rendering', function () {
+  describe('when challenge is not required', function () {
+    const { window } = new JSDOM('<body><div class="captcha" /></body>');
+    const element = window.document.querySelector('.captcha');
+
+    beforeEach(function () {
+      const mockClient = {
+        getChallenge: (cb) => cb(null, { required: false })
+      }
+      captcha.render(mockClient, element);
+    });
+
+    it('should hide the element', function () {
+      expect(element.style.display).to.equal('none');
+    });
+
+    it('should clean the innerHTML', function () {
+      expect(element.innerHTML).to.equal('');
+    });
+  });
+
+  describe('when challenge request fail', function () {
+    const { window } = new JSDOM('<body><div class="captcha" /></body>');
+    const element = window.document.querySelector('.captcha');
+    const callbackStub = sinon.stub();
+
+    beforeEach(function () {
+      const mockClient = {
+        getChallenge: (cb) => cb(new Error('network error'))
+      };
+      captcha.render(mockClient, element, {}, callbackStub);
+    });
+
+    it('should show the element', function () {
+      expect(element.style.display).to.equal('');
+    });
+
+    it('should show an error', function () {
+      expect(element.querySelector('div.error').innerHTML)
+        .to.equal('Error getting the bot detection challenge. Please contact the system administrator.')
+    });
+
+    it('should call the optional callback with the error', function () {
+      expect(callbackStub.called).to.equal(true)
+      expect(callbackStub.args[0][0].message).to.equal('network error')
+    });
+  });
+
+  describe('when challenge is required and the provider is auth0', function () {
+    const { window } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
+    const element = window.document.querySelector('.captcha');
+    const callbackStub = sinon.stub();
+
+    const challenges = [{
+      required: true,
+      provider: 'auth0',
+      image: 'img+svg///image1'
+    }, {
+      required: true,
+      provider: 'auth0',
+      image: 'img+svg///image2'
+    }];
+
+    let c;
+
+    beforeEach(function () {
+      const mockClient = {
+        challengeIndex: 0,
+        getChallenge(cb) {
+          cb(null, challenges[this.challengeIndex++]);
+        }
+      }
+      c = captcha.render(mockClient, element, {}, callbackStub);
+    });
+
+    it('should call the optional callback', function () {
+      expect(callbackStub.called).to.be.ok();
+      expect(callbackStub.args[0]).to.be.empty();
+    });
+
+    it('should show the element', function () {
+      expect(element.style.display).to.equal('');
+    });
+
+    it('should set the image tag', function () {
+      const imgEl = element.querySelector('img');
+      expect(imgEl.src).to.equal(challenges[0].image);
+    });
+
+    it('should contain an input tag with name captcha', function () {
+      const inputEl = element.querySelector('input[name="captcha"]');
+      expect(inputEl).to.be.ok();
+      expect(inputEl.type).to.contain('text');
+    });
+
+    it('should load a new image when clicking the reload button', function () {
+      const btn = element.querySelector('button.captcha-reload');
+      btn.click();
+      const imgEl = element.querySelector('img');
+      expect(imgEl.src).to.equal(challenges[1].image);
+    });
+
+    it('should load a new image when calling the reload method', function () {
+      c.reload();
+      const imgEl = element.querySelector('img');
+      expect(imgEl.src).to.equal(challenges[1].image);
+    });
+  });
+
+  describe('when challenge is required, the provider is auth0 and we use a custom template', function () {
+    const button = {
+      listeners: {},
+      addEventListener(event, handler) {
+        this.listeners[event] = handler;
+      }
+    };
+
+    const element = {
+      style: {},
+      display: 'none',
+      querySelector(selector) {
+        switch (selector) {
+          case '.captcha-reload':
+            return button;
+        }
+      }
+    };
+
+    const challenges = [{
+      required: true,
+      provider: 'auth0',
+      image: 'img+svg///image1'
+    }, {
+      required: true,
+      provider: 'auth0',
+      image: 'img+svg///image2'
+    }];
+
+    beforeEach(function () {
+      const mockClient = {
+        challengeIndex: 0,
+        getChallenge(cb) {
+          cb(null, challenges[this.challengeIndex++]);
+        }
+      }
+      captcha.render(mockClient, element, {
+        templates: {
+          auth0: challenge => `custom template: ${challenge.image}`
+        }
+      });
+    });
+
+    it('should show the element', function () {
+      expect(element.style.display).to.equal('');
+    });
+
+    it('should set the image tag', function () {
+      expect(element.innerHTML).to.equal(`custom template: ${challenges[0].image}`);
+    });
+  });
+
+  describe('when challenge is required and provider is recaptcha', function () {
+
+    const challenge = {
+      required: true,
+      provider: 'recaptcha_v2',
+      siteKey: 'blabla sitekey'
+    };
+
+    let c, recaptchaScript, scriptOnLoadCallback, element;
+
+    beforeEach(() => {
+      const { window } = new JSDOM('<body><div class="captcha" /></body>');
+      element = window.document.querySelector('.captcha');
+      global.window = window;
+      const mockClient = {
+        getChallenge(cb) {
+          cb(null, challenge);
+        }
+      };
+      c = captcha.render(mockClient, element);
+      recaptchaScript = [...window.document.querySelectorAll('script')].find(s => s.src.match('google\.com'));
+      scriptOnLoadCallback = window[url.parse(recaptchaScript.src, true).query.onload];
+    });
+
+    afterEach(function () {
+      delete global.window;
+    });
+
+    it('should inject the recaptcha script', function () {
+      expect(recaptchaScript.async).to.be.ok();
+      const scriptUrl = url.parse(recaptchaScript.src, true);
+      expect(scriptUrl.hostname).to.equal('www.google.com');
+      expect(scriptUrl.pathname).to.equal('/recaptcha/api.js');
+      expect(scriptUrl.query.hl).to.equal('en');
+      expect(scriptUrl.query).to.have.property('onload');
+    });
+
+    describe('after captcha is loaded', function () {
+      let renderOptions;
+      let renderElement;
+      let reseted = false;
+
+      beforeEach(function () {
+        reseted = false;
+        window.grecaptcha = {
+          render(element, options) {
+            renderElement = element;
+            renderOptions = options;
+            return 0;
+          },
+          reset() { reseted = true; }
+        };
+        scriptOnLoadCallback();
+      });
+
+      it('should render with the site key', function () {
+        expect(renderOptions.sitekey).to.equal(challenge.siteKey);
+      });
+
+      it('should set the value on the input when the user completes the captcha', function () {
+        const mockToken = 'token xxxxxx';
+        const input = element.querySelector('input[name="captcha"]');
+        renderOptions.callback(mockToken)
+        expect(input.value).to.equal(mockToken);
+      });
+
+      it('should clean the value when the token expires', function () {
+        const input = element.querySelector('input[name="captcha"]');
+        input.value = 'expired token';
+        renderOptions['expired-callback']()
+        expect(input.value).to.equal('');
+      });
+
+      it('should clean the value when there is an error', function () {
+        const input = element.querySelector('input[name="captcha"]');
+        input.value = 'expired token';
+        renderOptions['error-callback']()
+        expect(input.value).to.equal('');
+      });
+
+      it('should clean the value and reset when reloading', function () {
+        const input = element.querySelector('input[name="captcha"]');
+        input.value = 'old token';
+        c.reload();
+        expect(input.value).to.equal('');
+        expect(reseted).to.be.ok();
+      });
+
+    });
+  });
+});

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -8,12 +8,13 @@ describe('captcha rendering', function () {
   describe('when challenge is not required', function () {
     const { window } = new JSDOM('<body><div class="captcha" /></body>');
     const element = window.document.querySelector('.captcha');
+    let c;
 
     beforeEach(function () {
       const mockClient = {
         getChallenge: (cb) => cb(null, { required: false })
       }
-      captcha.render(mockClient, element);
+      c = captcha.render(mockClient, element);
     });
 
     it('should hide the element', function () {
@@ -22,6 +23,10 @@ describe('captcha rendering', function () {
 
     it('should clean the innerHTML', function () {
       expect(element.innerHTML).to.equal('');
+    });
+
+    it('should return undefined when calling getValue', function () {
+      expect(c.getValue()).to.be.equal(undefined);
     });
   });
 
@@ -97,6 +102,12 @@ describe('captcha rendering', function () {
       const inputEl = element.querySelector('input[name="captcha"]');
       expect(inputEl).to.be.ok();
       expect(inputEl.type).to.contain('text');
+    });
+
+    it('should return the user input when calling getValue()', function () {
+      const inputEl = element.querySelector('input[name="captcha"]');
+      inputEl.value = 'foobar';
+      expect(c.getValue()).to.equal('foobar');
     });
 
     it('should load a new image when clicking the reload button', function () {
@@ -229,6 +240,13 @@ describe('captcha rendering', function () {
         const input = element.querySelector('input[name="captcha"]');
         renderOptions.callback(mockToken)
         expect(input.value).to.equal(mockToken);
+      });
+
+
+      it('should return the value when calling getValue()', function () {
+        const mockToken = 'token xxxxxx';
+        renderOptions.callback(mockToken)
+        expect(c.getValue()).to.equal(mockToken);
       });
 
       it('should clean the value when the token expires', function () {

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -23,7 +23,7 @@ function restoreAndStubStoredTransaction(expectedState, expectedTransaction) {
   TransactionManager.prototype.getStoredTransaction.restore();
   sinon
     .stub(TransactionManager.prototype, 'getStoredTransaction')
-    .callsFake(function(state) {
+    .callsFake(function (state) {
       if (state !== 'ignore-test-state-check') {
         expect(state).to.be(expectedState);
       }
@@ -31,36 +31,36 @@ function restoreAndStubStoredTransaction(expectedState, expectedTransaction) {
     });
 }
 
-describe('auth0.WebAuth', function() {
+describe('auth0.WebAuth', function () {
   this.timeout(5000);
-  beforeEach(function() {
+  beforeEach(function () {
     sinon
       .stub(TransactionManager.prototype, 'generateTransaction')
-      .callsFake(function(appState, state, nonce) {
+      .callsFake(function (appState, state, nonce) {
         return { state: state || 'randomState', nonce: nonce || 'randomNonce' };
       });
     sinon
       .stub(TransactionManager.prototype, 'getStoredTransaction')
-      .callsFake(function(state) {
+      .callsFake(function (state) {
         expect(state).to.be('foo');
         return { state: 'foo' };
       });
   });
-  afterEach(function() {
+  afterEach(function () {
     TransactionManager.prototype.generateTransaction.restore();
     TransactionManager.prototype.getStoredTransaction.restore();
   });
 
-  context('init', function() {
-    after(function() {
+  context('init', function () {
+    after(function () {
       delete global.window;
     });
 
-    before(function() {
+    before(function () {
       global.window = {};
     });
 
-    it('should properly set the overrides', function() {
+    it('should properly set the overrides', function () {
       var webAuth = new WebAuth({
         domain: 'wptest.auth0.com',
         redirectUri: 'http://page.com/callback',
@@ -85,8 +85,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('nonce validation', function() {
-    beforeEach(function() {
+  context('nonce validation', function () {
+    beforeEach(function () {
       global.window = {
         location: {}
       };
@@ -96,14 +96,14 @@ describe('auth0.WebAuth', function() {
         appState: null
       });
     });
-    afterEach(function() {
+    afterEach(function () {
       delete global.window;
     });
 
-    it('should fail if the nonce is not valid', function(done) {
+    it('should fail if the nonce is not valid', function (done) {
       sinon
         .stub(SilentAuthenticationHandler.prototype, 'login')
-        .callsFake(function(usePostMessage, cb) {
+        .callsFake(function (usePostMessage, cb) {
           cb(
             null,
             '#state=foo&access_token=123&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA'
@@ -125,7 +125,7 @@ describe('auth0.WebAuth', function() {
         nonce: '123'
       };
 
-      webAuth.renewAuth(options, function(err, data) {
+      webAuth.renewAuth(options, function (err, data) {
         expect(err).to.eql({
           error: 'invalid_token',
           errorDescription: `Nonce (nonce) claim value mismatch in the ID token; expected "thenonce", found "asfd"`
@@ -139,27 +139,27 @@ describe('auth0.WebAuth', function() {
 
   context(
     'Pass correct postMessageData value to silent-authentication-handler',
-    function() {
-      before(function() {
+    function () {
+      before(function () {
         global.window = { origin: 'foobar' };
       });
 
-      after(function() {
+      after(function () {
         delete global.window;
       });
 
-      afterEach(function() {
+      afterEach(function () {
         SilentAuthenticationHandler.create.restore();
       });
 
-      it('should pass correct postMessageDataType=false value on to silent authentication handler', function(done) {
+      it('should pass correct postMessageDataType=false value on to silent authentication handler', function (done) {
         sinon
           .stub(SilentAuthenticationHandler, 'create')
-          .callsFake(function(options) {
+          .callsFake(function (options) {
             expect(options.postMessageDataType).to.be(false);
             done();
             return {
-              login: function() {}
+              login: function () { }
             };
           });
 
@@ -178,19 +178,19 @@ describe('auth0.WebAuth', function() {
           state: '456'
         };
 
-        webAuth.renewAuth(options, function(err, data) {});
+        webAuth.renewAuth(options, function (err, data) { });
       });
 
-      it('should pass correct postMessageDataType=<value> on to silent authentication handler', function(done) {
+      it('should pass correct postMessageDataType=<value> on to silent authentication handler', function (done) {
         sinon
           .stub(SilentAuthenticationHandler, 'create')
-          .callsFake(function(options) {
+          .callsFake(function (options) {
             expect(options.postMessageDataType).to.eql(
               'auth0:silent-authentication'
             );
             done();
             return {
-              login: function() {}
+              login: function () { }
             };
           });
 
@@ -210,17 +210,17 @@ describe('auth0.WebAuth', function() {
           postMessageDataType: 'auth0:silent-authentication'
         };
 
-        webAuth.renewAuth(options, function(err, data) {});
+        webAuth.renewAuth(options, function (err, data) { });
       });
 
-      it('should set a default postMessageOrigin to the window origin', function(done) {
+      it('should set a default postMessageOrigin to the window origin', function (done) {
         sinon
           .stub(SilentAuthenticationHandler, 'create')
-          .callsFake(function(options) {
+          .callsFake(function (options) {
             expect(options.postMessageOrigin).to.eql('foobar');
             done();
             return {
-              login: function() {}
+              login: function () { }
             };
           });
 
@@ -239,18 +239,18 @@ describe('auth0.WebAuth', function() {
           state: '456'
         };
 
-        webAuth.renewAuth(options, function(err, data) {});
+        webAuth.renewAuth(options, function (err, data) { });
       });
 
-      it('should use postMessageOrigin if provided', function(done) {
+      it('should use postMessageOrigin if provided', function (done) {
         var postMessageOrigin = 'foobar1';
         sinon
           .stub(SilentAuthenticationHandler, 'create')
-          .callsFake(function(options) {
+          .callsFake(function (options) {
             expect(options.postMessageOrigin).to.eql(postMessageOrigin);
             done();
             return {
-              login: function() {}
+              login: function () { }
             };
           });
 
@@ -270,13 +270,13 @@ describe('auth0.WebAuth', function() {
           postMessageOrigin: postMessageOrigin
         };
 
-        webAuth.renewAuth(options, function(err, data) {});
+        webAuth.renewAuth(options, function (err, data) { });
       });
     }
   );
 
-  context('parseHash', function() {
-    before(function() {
+  context('parseHash', function () {
+    before(function () {
       global.window = {
         location: {
           hash:
@@ -285,7 +285,7 @@ describe('auth0.WebAuth', function() {
       };
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       restoreAndStubStoredTransaction('foo', {
         nonce: 'asfd',
         state: 'foo',
@@ -295,22 +295,22 @@ describe('auth0.WebAuth', function() {
 
       sinon
         .stub(IdTokenVerifier.prototype, 'validateAccessToken')
-        .callsFake(function(at, alg, atHash, cb) {
+        .callsFake(function (at, alg, atHash, cb) {
           cb(null);
         });
 
       sinon
         .stub(IdTokenVerifier.prototype, 'getRsaVerifier')
-        .callsFake(function(iss, kid, cb) {
+        .callsFake(function (iss, kid, cb) {
           cb(null, {
-            verify: function() {
+            verify: function () {
               return true;
             }
           });
         });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       SSODataStorage.prototype.set.restore();
 
       if (IdTokenVerifier.prototype.validateAccessToken.restore) {
@@ -326,7 +326,7 @@ describe('auth0.WebAuth', function() {
       }
     });
 
-    it('should parse a valid hash without id_token', function(done) {
+    it('should parse a valid hash without id_token', function (done) {
       var webAuth = new WebAuth({
         domain: 'mdocs.auth0.com',
         redirectUri: 'http://example.com/callback',
@@ -339,7 +339,7 @@ describe('auth0.WebAuth', function() {
           hash:
             '#state=foo&access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
         },
-        function(err, data) {
+        function (err, data) {
           expect(data).to.eql({
             accessToken: 'VjubIMBmpgQ2W2',
             idToken: null,
@@ -360,13 +360,13 @@ describe('auth0.WebAuth', function() {
         }
       ); // eslint-disable-line
     });
-    it('should return the id_token payload when there is no access_token', function(done) {
+    it('should return the id_token payload when there is no access_token', function (done) {
       var webAuth = new WebAuth({
         domain: 'brucke.auth0.com',
         redirectUri: 'http://example.com/callback',
         clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
         responseType: 'id_token',
-        __clock: function() {
+        __clock: function () {
           return new Date(1521045300000);
         }
       });
@@ -377,7 +377,7 @@ describe('auth0.WebAuth', function() {
             '#state=foo&token_type=Bearer&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJuaWNrbmFtZSI6ImpvaG5mb28iLCJuYW1lIjoiam9obmZvb0BnbWFpbC5jb20iLCJwaWN0dXJlIjoiaHR0cHM6Ly9zLmdyYXZhdGFyLmNvbS9hdmF0YXIvMzhmYTAwMjQyM2JkOGM5NDFjNmVkMDU4OGI2MGZmZWQ_cz00ODAmcj1wZyZkPWh0dHBzJTNBJTJGJTJGY2RuLmF1dGgwLmNvbSUyRmF2YXRhcnMlMkZqby5wbmciLCJ1cGRhdGVkX2F0IjoiMjAxOC0wMy0xNFQxNjozNDo1Ni40MjNaIiwiZW1haWwiOiJqb2huZm9vQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiaXNzIjoiaHR0cHM6Ly9icnVja2UuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDVhMjA1NGZmNDUxNTc3MTFiZTgxODJmNCIsImF1ZCI6Ims1dTNvMmZpQUE4WHdlWEVFWDYwNEtDd0Nqemp0TVU2IiwiaWF0IjoxNTIxMDQ1Mjk2LCJleHAiOjE1MjEwODEyOTYsImF0X2hhc2giOiJjZHVrb2FVc3dNOWJvX3l6cmdWY3J3Iiwibm9uY2UiOiJsRkNuSTguY3JSVGRIZmRvNWsuek1YZlIzMTg1NmdLeiJ9.U4_F5Zw6xYVoHGiiem1wjz7i9eRaSOrt-L1e6hlu3wmqA-oNuVqf1tEYD9u0z5AbXXbQSr491A3VvUbLKjws13XETcljhaqigZ9q4HBpmzPlrUGmPreBLVQgGOaq5NVAViFTvORxYCMFLlc-SE6QI6xWF0AhFpoW7-hkOcOzXWAXqhkMgwAfjJ9aeOzSBgblmtx4duyNESBRefd3XPQrakWjGIqH3dFdc-lDFbY76eSLYfBi4AH-yim4egzB6LYOC-e2huZcHdmRAmEQaKZ7D7COBiGsgAPVGyjZtqfSQ2CRwNrAbxDwi8BqlLhQePOs6d3hqV-3OPLfdE6dUFh2DQ',
           nonce: 'lFCnI8.crRTdHfdo5k.zMXfR31856gKz'
         },
-        function(err, data) {
+        function (err, data) {
           if (err) {
             return done(err);
           }
@@ -416,7 +416,7 @@ describe('auth0.WebAuth', function() {
         }
       ); // eslint-disable-line
     });
-    it('should return the id_token payload when there is no payload.at_hash', function(done) {
+    it('should return the id_token payload when there is no payload.at_hash', function (done) {
       restoreAndStubStoredTransaction('foo', {
         state: 'foo',
         appState: null
@@ -435,7 +435,7 @@ describe('auth0.WebAuth', function() {
           hash:
             '#state=foo&token_type=Bearer&access_token=AiU65szv2vyh2xpom8Dqbkdwok4RRZkx&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJlbWFpbCI6ImpvaG5mb29AZ21haWwuY29tIiwidXNlcm5hbWUiOiJqb2huZm9vIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJ1c2VyX2lkIjoiYXV0aDB8NWEyMDU0ZmY0NTE1NzcxMWJlODE4MmY0IiwiY2xpZW50SUQiOiJCV0RQOVhTODlDSnExdzZOenE3aUZPSHNUaDZDaFMyYiIsInBpY3R1cmUiOiJodHRwczovL3MuZ3JhdmF0YXIuY29tL2F2YXRhci8zOGZhMDAyNDIzYmQ4Yzk0MWM2ZWQwNTg4YjYwZmZlZD9zPTQ4MCZyPXBnJmQ9aHR0cHMlM0ElMkYlMkZjZG4uYXV0aDAuY29tJTJGYXZhdGFycyUyRmpvLnBuZyIsIm5pY2tuYW1lIjoiam9obmZvbyIsImlkZW50aXRpZXMiOlt7InVzZXJfaWQiOiI1YTIwNTRmZjQ1MTU3NzExYmU4MTgyZjQiLCJwcm92aWRlciI6ImF1dGgwIiwiY29ubmVjdGlvbiI6ImFjbWUiLCJpc1NvY2lhbCI6ZmFsc2V9XSwidXBkYXRlZF9hdCI6IjIwMTgtMDMtMjJUMjM6MTI6MDIuNTc1WiIsImNyZWF0ZWRfYXQiOiIyMDE3LTExLTMwVDE4OjU5OjExLjM2OFoiLCJuYW1lIjoiam9obmZvb0BnbWFpbC5jb20iLCJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NWEyMDU0ZmY0NTE1NzcxMWJlODE4MmY0IiwiYXVkIjoiQldEUDlYUzg5Q0pxMXc2TnpxN2lGT0hzVGg2Q2hTMmIiLCJpYXQiOjE1MjE3NjAzMjIsImV4cCI6MTUyMTc5NjMyMn0.b1afXXSurcVvg71-9w0ABhxLfP5FCdSEPPDYqD8pj2yJXxdVbyK3kdd-caldW330FKwpJlibIbcT4Mz1EpkM_M4P7OyNb1_dJbEgXFoIyqshI4YyIOC0Hn95GPE4uBZMR4GH6O32Scw3KQl9M_pQOZrQySLvU-XNs0Ko99soZbivoc-HTLEXiHDEk9mmnQOBcz44XayMieLP5WQ3c-dDShpFw-Y-8QaaQr1WI1ailh_UdJeJq6SUdn4ItTPUWf7uhmDcWQPJyWh6MyHWBoL4iWh4ZEliVG8Js8J00higeoqP7rsrymb_Hvz5f801mzpro72zfar_tVMp144mH8A65g'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.be.eql({
             accessToken: 'AiU65szv2vyh2xpom8Dqbkdwok4RRZkx',
@@ -478,7 +478,7 @@ describe('auth0.WebAuth', function() {
         }
       ); // eslint-disable-line
     });
-    it('should return the id_token payload when there is a valid access_token', function(done) {
+    it('should return the id_token payload when there is a valid access_token', function (done) {
       var webAuth = new WebAuth({
         domain: 'brucke.auth0.com',
         redirectUri: 'http://example.com/callback',
@@ -493,7 +493,7 @@ describe('auth0.WebAuth', function() {
             '#state=foo&token_type=Bearer&access_token=L11oiFDHj3zmZid1AnsEuggXcMfjqe0X&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJuaWNrbmFtZSI6ImpvaG5mb28iLCJuYW1lIjoiam9obmZvb0BnbWFpbC5jb20iLCJwaWN0dXJlIjoiaHR0cHM6Ly9zLmdyYXZhdGFyLmNvbS9hdmF0YXIvMzhmYTAwMjQyM2JkOGM5NDFjNmVkMDU4OGI2MGZmZWQ_cz00ODAmcj1wZyZkPWh0dHBzJTNBJTJGJTJGY2RuLmF1dGgwLmNvbSUyRmF2YXRhcnMlMkZqby5wbmciLCJ1cGRhdGVkX2F0IjoiMjAxOC0wMy0yMVQyMDowNDo0Mi40OTNaIiwiZW1haWwiOiJqb2huZm9vQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiaXNzIjoiaHR0cHM6Ly9icnVja2UuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDVhMjA1NGZmNDUxNTc3MTFiZTgxODJmNCIsImF1ZCI6Ims1dTNvMmZpQUE4WHdlWEVFWDYwNEtDd0Nqemp0TVU2IiwiaWF0IjoxNTIxNjYyNjgyLCJleHAiOjE1MjE2OTg2ODIsImF0X2hhc2giOiJKS2NaM3hTQ2NGVEE5NkxuQ3lJX0FRIiwibm9uY2UiOiJLdlhoc1VIc2VJSEl5emF1X2JVflJHQ2t1RUFDTE5HaiJ9.UbiWFikCkoX-m22mFnXJhKMY8M9BGMDJqZZ5J-iUAQwOmD-33-zX-AjSbD6zL6sOJoKJratJLtLa90tE3sDeokI9c8GE_JonfeF95knVPAx99tD5eCIJabV8HN_K1rfcgI_ed9v8RKQD9_dRkwUMHgXyceWeijnA9k8jG-pe1iXAtnn386G5s6fj-do8SUvC2MFWNmD5VhkW-CyEg_Chui8BoOSM9d7liMZRQkgKA2aGl5t2qqvOu0ZNJwaWoeQ5T0R-h2Yk6Om_alFKyLdZXsZY2LRYQdbk4nEgxY59241HPZGHYOTJN5uLlbcxKyouTyM7Gt4dE76wyRh9kBr47A',
           nonce: 'KvXhsUHseIHIyzau_bU~RGCkuEACLNGj'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.be.eql({
             accessToken: 'L11oiFDHj3zmZid1AnsEuggXcMfjqe0X',
@@ -526,7 +526,7 @@ describe('auth0.WebAuth', function() {
         }
       ); // eslint-disable-line
     });
-    it('should validate an access_token when available', function(done) {
+    it('should validate an access_token when available', function (done) {
       var webAuth = new WebAuth({
         domain: 'brucke.auth0.com',
         redirectUri: 'http://example.com/callback',
@@ -542,7 +542,7 @@ describe('auth0.WebAuth', function() {
             '#state=foo&token_type=Bearer&access_token=YTvJcYrrZYHUXLZK5leLnfmD5ZIA_EA&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJuaWNrbmFtZSI6ImpvaG5mb28iLCJuYW1lIjoiam9obmZvb0BnbWFpbC5jb20iLCJwaWN0dXJlIjoiaHR0cHM6Ly9zLmdyYXZhdGFyLmNvbS9hdmF0YXIvMzhmYTAwMjQyM2JkOGM5NDFjNmVkMDU4OGI2MGZmZWQ_cz00ODAmcj1wZyZkPWh0dHBzJTNBJTJGJTJGY2RuLmF1dGgwLmNvbSUyRmF2YXRhcnMlMkZqby5wbmciLCJ1cGRhdGVkX2F0IjoiMjAxOC0wMy0xNFQxNjozNDo1Ni40MjNaIiwiZW1haWwiOiJqb2huZm9vQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiaXNzIjoiaHR0cHM6Ly9icnVja2UuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDVhMjA1NGZmNDUxNTc3MTFiZTgxODJmNCIsImF1ZCI6Ims1dTNvMmZpQUE4WHdlWEVFWDYwNEtDd0Nqemp0TVU2IiwiaWF0IjoxNTIxMDQ1Mjk2LCJleHAiOjE1MjEwODEyOTYsImF0X2hhc2giOiJjZHVrb2FVc3dNOWJvX3l6cmdWY3J3Iiwibm9uY2UiOiJsRkNuSTguY3JSVGRIZmRvNWsuek1YZlIzMTg1NmdLeiJ9.U4_F5Zw6xYVoHGiiem1wjz7i9eRaSOrt-L1e6hlu3wmqA-oNuVqf1tEYD9u0z5AbXXbQSr491A3VvUbLKjws13XETcljhaqigZ9q4HBpmzPlrUGmPreBLVQgGOaq5NVAViFTvORxYCMFLlc-SE6QI6xWF0AhFpoW7-hkOcOzXWAXqhkMgwAfjJ9aeOzSBgblmtx4duyNESBRefd3XPQrakWjGIqH3dFdc-lDFbY76eSLYfBi4AH-yim4egzB6LYOC-e2huZcHdmRAmEQaKZ7D7COBiGsgAPVGyjZtqfSQ2CRwNrAbxDwi8BqlLhQePOs6d3hqV-3OPLfdE6dUFh2DQ',
           nonce: 'lFCnI8.crRTdHfdo5k.zMXfR31856gKz'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be.eql({
             error: 'invalid_token',
             errorDescription: 'Invalid access_token'
@@ -552,8 +552,8 @@ describe('auth0.WebAuth', function() {
       ); // eslint-disable-line
     });
 
-    context('when there is a transaction', function() {
-      it('should return transaction.appState', function(done) {
+    context('when there is a transaction', function () {
+      it('should return transaction.appState', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -563,7 +563,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return {
               nonce: 'asfd',
               appState: 'the-app-state',
@@ -576,7 +576,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(data).to.eql({
               accessToken: 'VjubIMBmpgQ2W2',
               idToken: null,
@@ -597,8 +597,8 @@ describe('auth0.WebAuth', function() {
           }
         ); // eslint-disable-line
       });
-      context('when there is a transaction.lastUsedConnection', function() {
-        beforeEach(function() {
+      context('when there is a transaction.lastUsedConnection', function () {
+        beforeEach(function () {
           this.webAuth = new WebAuth({
             domain: 'brucke.auth0.com',
             redirectUri: 'http://example.com/callback',
@@ -609,14 +609,14 @@ describe('auth0.WebAuth', function() {
           TransactionManager.prototype.getStoredTransaction.restore();
           sinon
             .stub(TransactionManager.prototype, 'getStoredTransaction')
-            .callsFake(function() {
+            .callsFake(function () {
               return {
                 lastUsedConnection: 'lastUsedConnection',
                 state: 'foo'
               };
             });
         });
-        it('sets ssodata with a connection and without a sub when there is no payload', function(done) {
+        it('sets ssodata with a connection and without a sub when there is no payload', function (done) {
           var webAuth = new WebAuth({
             domain: 'brucke.auth0.com',
             redirectUri: 'http://example.com/callback',
@@ -629,7 +629,7 @@ describe('auth0.WebAuth', function() {
               hash:
                 '#state=foo&access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
             },
-            function(err) {
+            function (err) {
               if (err) return done(err);
 
               expect(SSODataStorage.prototype.set.calledOnce).to.be.ok();
@@ -644,14 +644,14 @@ describe('auth0.WebAuth', function() {
             }
           ); // eslint-disable-line
         });
-        it('sets ssodata with a connection and a sub when there is a payload', function(done) {
+        it('sets ssodata with a connection and a sub when there is a payload', function (done) {
           this.webAuth.parseHash(
             {
               hash:
                 '#state=foo&access_token=VjubIMBmpgQ2W2&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik5FVkJOVU5CT1RneFJrRTVOa1F6UXpjNE9UQkVNRUZGUkRRNU4wUTJRamswUmtRMU1qRkdNUSJ9.eyJpc3MiOiJodHRwczovL2JydWNrZS5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTlmYmUxMTkzNzAzOWIyNjNhOGIyOWEyIiwiYXVkIjoiazV1M28yZmlBQThYd2VYRUVYNjA0S0N3Q2p6anRNVTYiLCJpYXQiOjE1MTE1NTE3ODMsImV4cCI6MTUxMTU4Nzc4MywiYXRfaGFzaCI6IkxGTDMxMlRXWDFGc1VNay00R2gxYWciLCJub25jZSI6IndFT2U3LUxDOG5sMUF1SHA3bnVjRl81TE1WUFZrTUJZIn0.fUJhEIPded3aO4iDrbniwGnAEZHX66Mjl7yCgIxSSCXlgrHlOATvbMi7XGQXNfPjGCivySoalMCS3MikvMGBFPFguChyJZ3myswT6US33hZSTycUYODvWSz8j7PeEpJrHdF4nAO4NvbC4JjogG92Xg2zx0KCZtoLK9datZiWEWHVUEVEXZCwceyowxQ4J5dqDzzLm9_V9qBsUYJtINqMM6jhHazk7OQUFZlE35R3l-Lps2oofqxZf11X7g0bgxo5ykSSr_KDvj9Hx0flk_u-eTTD2XVGMWe1TreJm1KMMuD01PicU1JGsJRA0hqE6Fd943OAEAIM6feMximK22rrHg',
               nonce: 'wEOe7-LC8nl1AuHp7nucF_5LMVPVkMBY'
             },
-            function(err) {
+            function (err) {
               if (err) return done(err);
 
               expect(SSODataStorage.prototype.set.calledOnce).to.be.ok();
@@ -670,8 +670,8 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    context('with RS256 id_token', function() {
-      it('should parse a valid hash', function(done) {
+    context('with RS256 id_token', function () {
+      it('should parse a valid hash', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -686,7 +686,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas&scope=foo'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               accessToken: 'VjubIMBmpgQ2W2',
@@ -717,7 +717,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should parse a valid hash from the location.hash', function(done) {
+      it('should parse a valid hash from the location.hash', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -726,7 +726,7 @@ describe('auth0.WebAuth', function() {
           __clock: () => new Date(1482933050000)
         });
 
-        webAuth.parseHash({ nonce: 'asfd' }, function(err, data) {
+        webAuth.parseHash({ nonce: 'asfd' }, function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             accessToken: 'asldkfjahsdlkfjhasd',
@@ -756,7 +756,7 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      it('should parse a valid hash from the location.hash even if transaction is null but state & nonce passed as parameters', function(done) {
+      it('should parse a valid hash from the location.hash even if transaction is null but state & nonce passed as parameters', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -769,7 +769,7 @@ describe('auth0.WebAuth', function() {
 
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return null;
           });
 
@@ -780,7 +780,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=123&access_token=asldkfjahsdlkfjhasd&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               accessToken: 'asldkfjahsdlkfjhasd',
@@ -811,7 +811,7 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should bypass state checking when options.__enableIdPInitiatedLogin is set to true and there is no state in the hash and in the transaction', function(done) {
+      it('should bypass state checking when options.__enableIdPInitiatedLogin is set to true and there is no state in the hash and in the transaction', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -822,7 +822,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return null;
           });
 
@@ -833,7 +833,7 @@ describe('auth0.WebAuth', function() {
               '#access_token=asldkfjahsdlkfjhasd&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas',
             __enableIdPInitiatedLogin: true
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               accessToken: 'asldkfjahsdlkfjhasd',
@@ -863,7 +863,7 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
-      it('should bypass state checking when options.__enableImpersonation is set to true and there is no state in the hash and in the transaction', function(done) {
+      it('should bypass state checking when options.__enableImpersonation is set to true and there is no state in the hash and in the transaction', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -874,7 +874,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return null;
           });
 
@@ -885,7 +885,7 @@ describe('auth0.WebAuth', function() {
               '#access_token=asldkfjahsdlkfjhasd&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas',
             __enableImpersonation: true
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               accessToken: 'asldkfjahsdlkfjhasd',
@@ -916,7 +916,7 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should fail when there is no state available in the hash', function(done) {
+      it('should fail when there is no state available in the hash', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -926,7 +926,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return null;
           });
 
@@ -935,7 +935,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -945,7 +945,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail with an invalid state (null transaction)', function(done) {
+      it('should fail with an invalid state (null transaction)', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -955,7 +955,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return null;
           });
 
@@ -964,7 +964,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -974,7 +974,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail with an invalid state (available transaction)', function(done) {
+      it('should fail with an invalid state (available transaction)', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -984,7 +984,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return {
               state: 'not-123'
             };
@@ -995,7 +995,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -1005,7 +1005,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail with an invalid state (available transaction with __enableIdPInitiatedLogin:true)', function(done) {
+      it('should fail with an invalid state (available transaction with __enableIdPInitiatedLogin:true)', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1015,7 +1015,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return {
               state: 'not-123'
             };
@@ -1027,7 +1027,7 @@ describe('auth0.WebAuth', function() {
               '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas',
             __enableIdPInitiatedLogin: true
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -1036,7 +1036,7 @@ describe('auth0.WebAuth', function() {
           }
         ); // eslint-disable-line
       });
-      it('should fail with an invalid state (available transaction with __enableImpersonation:true)', function(done) {
+      it('should fail with an invalid state (available transaction with __enableImpersonation:true)', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1046,7 +1046,7 @@ describe('auth0.WebAuth', function() {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return {
               state: 'not-123'
             };
@@ -1058,7 +1058,7 @@ describe('auth0.WebAuth', function() {
               '#state=123&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas',
             __enableImpersonation: true
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -1068,7 +1068,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail with an invalid audience', function(done) {
+      it('should fail with an invalid audience', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1081,7 +1081,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription:
@@ -1092,7 +1092,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail with an invalid issuer', function(done) {
+      it('should fail with an invalid issuer', function (done) {
         var webAuth = new WebAuth({
           domain: 'wptest_2.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1105,7 +1105,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'invalid_token',
               errorDescription:
@@ -1116,7 +1116,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should fail if there is no token', function(done) {
+      it('should fail if there is no token', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs_2.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1128,7 +1128,7 @@ describe('auth0.WebAuth', function() {
           {
             hash: '#token_type=Bearer'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.be(null);
             done();
@@ -1136,7 +1136,7 @@ describe('auth0.WebAuth', function() {
         ); // eslint-disable-line
       });
 
-      it('should parse an error response', function(done) {
+      it('should parse an error response', function (done) {
         var webAuth = new WebAuth({
           domain: 'mdocs_2.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1149,7 +1149,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#error=the_error_code&error_description=the_error_description&state=some_state'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.eql({
               error: 'the_error_code',
               errorDescription: 'the_error_description',
@@ -1160,11 +1160,11 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should return default error if it is not a validation error', function(done) {
+      it('should return default error if it is not a validation error', function (done) {
         var expectedError = { error: 'some_error' };
         sinon
           .stub(WebAuth.prototype, 'validateToken')
-          .callsFake(function(token, nonce, callback) {
+          .callsFake(function (token, nonce, callback) {
             return callback(expectedError);
           });
         var webAuth = new WebAuth({
@@ -1179,22 +1179,22 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&token_type=Bearer&id_token=0as98da09s8d_not_a_token'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be.eql(expectedError);
             done();
           }
         );
       });
-      describe('should throw invalid_hash error', function() {
-        afterEach(function() {
+      describe('should throw invalid_hash error', function () {
+        afterEach(function () {
           if (WebAuth.prototype.validateAuthenticationResponse.restore) {
             WebAuth.prototype.validateAuthenticationResponse.restore();
           }
         });
-        it('does not validate when there is no responseType set', function(done) {
+        it('does not validate when there is no responseType set', function (done) {
           sinon
             .stub(WebAuth.prototype, 'validateAuthenticationResponse')
-            .callsFake(function() {
+            .callsFake(function () {
               done();
             });
           var webAuth = new WebAuth({
@@ -1208,7 +1208,7 @@ describe('auth0.WebAuth', function() {
               '#state=foo&token_type=Bearer&id_token=0as98da09s8d_not_a_token'
           });
         });
-        it('when baseoptions.response_type includes token but parsedHash has no access_token', function(done) {
+        it('when baseoptions.response_type includes token but parsedHash has no access_token', function (done) {
           var expectedError = {
             error: 'invalid_hash',
             errorDescription:
@@ -1226,13 +1226,13 @@ describe('auth0.WebAuth', function() {
               hash:
                 '#state=foo&token_type=Bearer&id_token=0as98da09s8d_not_a_token'
             },
-            function(err, data) {
+            function (err, data) {
               expect(err).to.be.eql(expectedError);
               done();
             }
           );
         });
-        it('when baseoptions.response_type includes id_token but parsedHash has no id_token', function(done) {
+        it('when baseoptions.response_type includes id_token but parsedHash has no id_token', function (done) {
           var expectedError = {
             error: 'invalid_hash',
             errorDescription:
@@ -1250,13 +1250,13 @@ describe('auth0.WebAuth', function() {
               hash:
                 '#state=foo&token_type=Bearer&access_token=0as98da09s8d_not_a_token'
             },
-            function(err, data) {
+            function (err, data) {
               expect(err).to.be.eql(expectedError);
               done();
             }
           );
         });
-        it('when options.response_type includes token but parsedHash has no access_token', function(done) {
+        it('when options.response_type includes token but parsedHash has no access_token', function (done) {
           var expectedError = {
             error: 'invalid_hash',
             errorDescription:
@@ -1274,13 +1274,13 @@ describe('auth0.WebAuth', function() {
                 '#state=foo&token_type=Bearer&id_token=0as98da09s8d_not_a_token',
               responseType: 'code token'
             },
-            function(err, data) {
+            function (err, data) {
               expect(err).to.be.eql(expectedError);
               done();
             }
           );
         });
-        it('when options.response_type includes id_token but parsedHash has no id_token', function(done) {
+        it('when options.response_type includes id_token but parsedHash has no id_token', function (done) {
           var expectedError = {
             error: 'invalid_hash',
             errorDescription:
@@ -1298,7 +1298,7 @@ describe('auth0.WebAuth', function() {
                 '#state=foo&token_type=Bearer&access_token=0as98da09s8d_not_a_token',
               responseType: 'code id_token'
             },
-            function(err, data) {
+            function (err, data) {
               expect(err).to.be.eql(expectedError);
               done();
             }
@@ -1306,8 +1306,8 @@ describe('auth0.WebAuth', function() {
         });
       });
     });
-    context('with HS256 id_token', function() {
-      beforeEach(function() {
+    context('with HS256 id_token', function () {
+      beforeEach(function () {
         this.webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1316,7 +1316,7 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         if (this.webAuth.client.userInfo.restore) {
           this.webAuth.client.userInfo.restore();
         }
@@ -1325,10 +1325,10 @@ describe('auth0.WebAuth', function() {
         }
       });
 
-      it('should use result from /userinfo as idTokenPayload', function(done) {
+      it('should use result from /userinfo as idTokenPayload', function (done) {
         sinon
           .stub(this.webAuth.client, 'userInfo')
-          .callsFake(function(accessToken, cb) {
+          .callsFake(function (accessToken, cb) {
             expect(accessToken).to.be('VjubIMBmpgQ2W2');
             cb(null, { from: 'userinfo' });
           });
@@ -1339,7 +1339,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjA4ODU1NzgsImV4cCI6MTU5MjQyMTU3OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIm5vbmNlIjoidGhlLW5vbmNlIn0.jb9aG21kGibxKPIyfn8FfvjQ3ykJGiBGcep2hDHHfqk&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.be.eql({
               accessToken: 'VjubIMBmpgQ2W2',
@@ -1358,11 +1358,11 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should not throw an error when the payload.nonce is undefined and transactionNonce is null', function(done) {
+      it('should not throw an error when the payload.nonce is undefined and transactionNonce is null', function (done) {
         TransactionManager.prototype.getStoredTransaction.restore();
         sinon
           .stub(TransactionManager.prototype, 'getStoredTransaction')
-          .callsFake(function() {
+          .callsFake(function () {
             return {
               nonce: null,
               state: 'foo'
@@ -1377,14 +1377,14 @@ describe('auth0.WebAuth', function() {
 
         sinon
           .stub(webAuth.client, 'userInfo')
-          .callsFake(function(accessToken, cb) {
+          .callsFake(function (accessToken, cb) {
             expect(accessToken).to.be('VjubIMBmpgQ2W2');
             cb(null, { from: 'userinfo' });
           });
 
         sinon
           .stub(IdTokenVerifier.prototype, 'verify')
-          .callsFake(function(_, __, cb) {
+          .callsFake(function (_, __, cb) {
             cb({ error: true });
           });
 
@@ -1394,7 +1394,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjE2NjM3ODMsImV4cCI6MTU5MzE5OTc4MywiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.Hoq1Go3McuHgSMg9rWVxQsEenoDWYi5MEumc32Ah9CQ&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.be.eql({
               accessToken: 'VjubIMBmpgQ2W2',
@@ -1413,7 +1413,7 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should still throw an error with an invalid nonce', function(done) {
+      it('should still throw an error with an invalid nonce', function (done) {
         var webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1422,7 +1422,7 @@ describe('auth0.WebAuth', function() {
         });
         sinon
           .stub(IdTokenVerifier.prototype, 'verify')
-          .callsFake(function(_, __, cb) {
+          .callsFake(function (_, __, cb) {
             cb({ error: true });
           });
 
@@ -1432,7 +1432,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjA4ODU1NzgsImV4cCI6MTU5MjQyMTU3OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIm5vbmNlIjoidGhlLW5vbmNlIn0.jb9aG21kGibxKPIyfn8FfvjQ3ykJGiBGcep2hDHHfqk&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be.eql({
               error: 'invalid_token',
               errorDescription:
@@ -1443,7 +1443,7 @@ describe('auth0.WebAuth', function() {
         );
       });
 
-      it('should still throw an error with an invalid state', function(done) {
+      it('should still throw an error with an invalid state', function (done) {
         var webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1452,7 +1452,7 @@ describe('auth0.WebAuth', function() {
         });
         sinon
           .stub(IdTokenVerifier.prototype, 'verify')
-          .callsFake(function(_, __, cb) {
+          .callsFake(function (_, __, cb) {
             cb({ error: true });
           });
 
@@ -1462,7 +1462,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=ignore-test-state-check&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjA4ODU1NzgsImV4cCI6MTU5MjQyMTU3OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIm5vbmNlIjoidGhlLW5vbmNlIn0.jb9aG21kGibxKPIyfn8FfvjQ3ykJGiBGcep2hDHHfqk&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be.eql({
               error: 'invalid_token',
               errorDescription: '`state` does not match.'
@@ -1471,7 +1471,7 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
-      it('should throw an error when there is no access_token to call /userinfo', function(done) {
+      it('should throw an error when there is no access_token to call /userinfo', function (done) {
         var webAuth = new WebAuth({
           domain: 'auth0-tests-lock.auth0.com',
           redirectUri: 'http://example.com/callback',
@@ -1480,7 +1480,7 @@ describe('auth0.WebAuth', function() {
         });
         sinon
           .stub(webAuth.client, 'userInfo')
-          .callsFake(function(accessToken, cb) {
+          .callsFake(function (accessToken, cb) {
             cb({ any: 'error' });
           });
 
@@ -1490,7 +1490,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjA4ODU1NzgsImV4cCI6MTU5MjQyMTU3OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIm5vbmNlIjoidGhlLW5vbmNlIn0.jb9aG21kGibxKPIyfn8FfvjQ3ykJGiBGcep2hDHHfqk&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be.eql({
               error: 'invalid_token',
               description:
@@ -1500,10 +1500,10 @@ describe('auth0.WebAuth', function() {
           }
         );
       });
-      it('should throw original userinfo error when /userinfo call has an error', function(done) {
+      it('should throw original userinfo error when /userinfo call has an error', function (done) {
         sinon
           .stub(this.webAuth.client, 'userInfo')
-          .callsFake(function(accessToken, cb) {
+          .callsFake(function (accessToken, cb) {
             cb({ any: 'error' });
           });
 
@@ -1513,7 +1513,7 @@ describe('auth0.WebAuth', function() {
             hash:
               '#state=foo&access_token=VjubIMBmpgQ2W2&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE1NjA4ODU1NzgsImV4cCI6MTU5MjQyMTU3OCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIm5vbmNlIjoidGhlLW5vbmNlIn0.jb9aG21kGibxKPIyfn8FfvjQ3ykJGiBGcep2hDHHfqk&token_type=Bearer&refresh_token=kajshdgfkasdjhgfas'
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be.eql({ any: 'error' });
             done();
           }
@@ -1522,22 +1522,22 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('renewAuth', function() {
-    beforeEach(function() {
+  context('renewAuth', function () {
+    beforeEach(function () {
       global.window = {
         origin: 'unit-test-origin',
-        removeEventListener: function() {}
+        removeEventListener: function () { }
       };
     });
-    afterEach(function() {
+    afterEach(function () {
       delete global.window;
       SilentAuthenticationHandler.prototype.login.restore();
     });
 
-    it('should pass the correct authorize url', function(done) {
+    it('should pass the correct authorize url', function (done) {
       sinon
         .stub(SilentAuthenticationHandler.prototype, 'login')
-        .callsFake(function() {
+        .callsFake(function () {
           expect(this.authenticationUrl).to.be(
             'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&scope=openid%20name%20read%3Ablog&audience=urn%3Asite%3Ademo%3Ablog&nonce=123&state=456&response_mode=fragment&prompt=none'
           );
@@ -1559,13 +1559,13 @@ describe('auth0.WebAuth', function() {
         state: '456'
       };
 
-      webAuth.renewAuth(options, function() {});
+      webAuth.renewAuth(options, function () { });
     });
 
-    it('should pass the correct timeout', function(done) {
+    it('should pass the correct timeout', function (done) {
       sinon
         .stub(SilentAuthenticationHandler.prototype, 'login')
-        .callsFake(function() {
+        .callsFake(function () {
           expect(this.timeout).to.be(5000);
           done();
         });
@@ -1586,18 +1586,18 @@ describe('auth0.WebAuth', function() {
         timeout: 5000
       };
 
-      webAuth.renewAuth(options, function() {});
+      webAuth.renewAuth(options, function () { });
     });
   });
 
-  context('authorize', function() {
-    beforeEach(function() {
+  context('authorize', function () {
+    beforeEach(function () {
       global.window = { location: '' };
     });
-    afterEach(function() {
+    afterEach(function () {
       delete global.window;
     });
-    it('should default scope to openid profile email', function(done) {
+    it('should default scope to openid profile email', function (done) {
       var webAuth = new WebAuth({
         domain: 'me.auth0.com',
         redirectUri: 'http://page.com/callback',
@@ -1605,7 +1605,7 @@ describe('auth0.WebAuth', function() {
         responseType: 'token',
         _sendTelemetry: false
       });
-      sinon.stub(windowHelper, 'redirect').callsFake(function(url) {
+      sinon.stub(windowHelper, 'redirect').callsFake(function (url) {
         expect(url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&connection=foobar&state=randomState&scope=openid%20profile%20email'
         );
@@ -1615,7 +1615,7 @@ describe('auth0.WebAuth', function() {
 
       webAuth.authorize({ connection: 'foobar' });
     });
-    it('should check that responseType is present', function() {
+    it('should check that responseType is present', function () {
       var webAuth = new WebAuth({
         domain: 'me.auth0.com',
         redirectUri: 'http://page.com/callback',
@@ -1625,31 +1625,31 @@ describe('auth0.WebAuth', function() {
         _sendTelemetry: false
       });
 
-      expect(function() {
+      expect(function () {
         webAuth.authorize({ connection: 'facebook' });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('responseType option is required');
       });
     });
   });
 
-  context('renewAuth', function() {
-    beforeEach(function() {
+  context('renewAuth', function () {
+    beforeEach(function () {
       global.window = {
         document: {},
         origin: 'unit-test-origin'
       };
     });
 
-    afterEach(function() {
+    afterEach(function () {
       delete global.window;
       SilentAuthenticationHandler.prototype.login.restore();
     });
 
-    it('should validate the token', function(done) {
+    it('should validate the token', function (done) {
       sinon
         .stub(SilentAuthenticationHandler.prototype, 'login')
-        .callsFake(function(usePostMessage, cb) {
+        .callsFake(function (usePostMessage, cb) {
           cb(
             null,
             '#state=foo&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA'
@@ -1658,7 +1658,7 @@ describe('auth0.WebAuth', function() {
       TransactionManager.prototype.getStoredTransaction.restore();
       sinon
         .stub(TransactionManager.prototype, 'getStoredTransaction')
-        .callsFake(function() {
+        .callsFake(function () {
           return {
             nonce: 'asfd',
             state: 'foo'
@@ -1680,7 +1680,7 @@ describe('auth0.WebAuth', function() {
         nonce: 'asfd'
       };
 
-      webAuth.renewAuth(options, function(err, data) {
+      webAuth.renewAuth(options, function (err, data) {
         expect(err).to.be(null);
         expect(data).to.eql({
           accessToken: null,
@@ -1705,17 +1705,17 @@ describe('auth0.WebAuth', function() {
         done();
       });
     });
-    describe('should return the access_token', function() {
-      beforeEach(function() {
+    describe('should return the access_token', function () {
+      beforeEach(function () {
         global.window = { origin: 'unit-test-origin' };
       });
-      afterEach(function() {
+      afterEach(function () {
         delete global.window;
       });
-      it('when login returns an object', function(done) {
+      it('when login returns an object', function (done) {
         sinon
           .stub(SilentAuthenticationHandler.prototype, 'login')
-          .callsFake(function(usePostMessage, cb) {
+          .callsFake(function (usePostMessage, cb) {
             cb(null, { accessToken: '123' });
           });
 
@@ -1731,7 +1731,7 @@ describe('auth0.WebAuth', function() {
 
         var options = {};
 
-        webAuth.renewAuth(options, function(err, data) {
+        webAuth.renewAuth(options, function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             accessToken: '123'
@@ -1739,10 +1739,10 @@ describe('auth0.WebAuth', function() {
           done();
         });
       });
-      it('when login returns a string', function(done) {
+      it('when login returns a string', function (done) {
         sinon
           .stub(SilentAuthenticationHandler.prototype, 'login')
-          .callsFake(function(usePostMessage, cb) {
+          .callsFake(function (usePostMessage, cb) {
             cb(
               null,
               '#state=foo&access_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1'
@@ -1761,7 +1761,7 @@ describe('auth0.WebAuth', function() {
 
         var options = {};
 
-        webAuth.renewAuth(options, function(err, data) {
+        webAuth.renewAuth(options, function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             accessToken: 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1',
@@ -1779,10 +1779,10 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    it('should validate the token and fail with invalid audience error', function(done) {
+    it('should validate the token and fail with invalid audience error', function (done) {
       sinon
         .stub(SilentAuthenticationHandler.prototype, 'login')
-        .callsFake(function(usePostMessage, cb) {
+        .callsFake(function (usePostMessage, cb) {
           cb(
             null,
             '#state=foo&access_token=123&id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6RTROMFpCTTBWRFF6RTJSVVUwTnpJMVF6WTFNelE0UVRrMU16QXdNRUk0UkRneE56RTRSZyJ9.eyJpc3MiOiJodHRwczovL3dwdGVzdC5hdXRoMC5jb20vIiwic3ViIjoiYXV0aDB8NTVkNDhjNTdkNWIwYWQwMjIzYzQwOGQ3IiwiYXVkIjoiZ1lTTmxVNFlDNFYxWVBkcXE4elBRY3VwNnJKdzFNYnQiLCJleHAiOjE0ODI5NjkwMzEsImlhdCI6MTQ4MjkzMzAzMSwibm9uY2UiOiJhc2ZkIn0.PPoh-pITcZ8qbF5l5rMZwXiwk5efbESuqZ0IfMUcamB6jdgLwTxq-HpOT_x5q6-sO1PBHchpSo1WHeDYMlRrOFd9bh741sUuBuXdPQZ3Zb0i2sNOAC2RFB1E11mZn7uNvVPGdPTg-Y5xppz30GSXoOJLbeBszfrVDCmPhpHKGGMPL1N6HV-3EEF77L34YNAi2JQ-b70nFK_dnYmmv0cYTGUxtGTHkl64UEDLi3u7bV-kbGky3iOOCzXKzDDY6BBKpCRTc2KlbrkO2A2PuDn27WVv1QCNEFHvJN7HxiDDzXOsaUmjrQ3sfrHhzD7S9BcCRkekRfD9g95SKD5J0Fj8NA'
@@ -1803,7 +1803,7 @@ describe('auth0.WebAuth', function() {
         nonce: '123'
       };
 
-      webAuth.renewAuth(options, function(err, data) {
+      webAuth.renewAuth(options, function (err, data) {
         expect(data).to.be(undefined);
         expect(err).to.eql({
           error: 'invalid_token',
@@ -1815,8 +1815,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('change password', function() {
-    before(function() {
+  context('change password', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -1826,12 +1826,12 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       request.post.restore();
     });
 
-    it('should call db-connection changePassword with all the options', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call db-connection changePassword with all the options', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/dbconnections/change_password');
         return new RequestMock({
           body: {
@@ -1842,7 +1842,7 @@ describe('auth0.WebAuth', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(null, {});
           }
         });
@@ -1853,15 +1853,15 @@ describe('auth0.WebAuth', function() {
           connection: 'the_connection',
           email: 'me@example.com'
         },
-        function(err) {
+        function (err) {
           expect(err).to.be(null);
           done();
         }
       );
     });
 
-    it('should call db-connection changePassword should ignore password option', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call db-connection changePassword should ignore password option', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/dbconnections/change_password');
         return new RequestMock({
           body: {
@@ -1872,7 +1872,7 @@ describe('auth0.WebAuth', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(null, {});
           }
         });
@@ -1884,7 +1884,7 @@ describe('auth0.WebAuth', function() {
           email: 'me@example.com',
           password: '123456'
         },
-        function(err) {
+        function (err) {
           expect(err).to.be(null);
           done();
         }
@@ -1892,8 +1892,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('passwordless start', function() {
-    before(function() {
+  context('passwordless start', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -1903,7 +1903,7 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       TransactionManager.prototype.process.restore();
       if (request.post.restore) {
         request.post.restore();
@@ -1912,10 +1912,10 @@ describe('auth0.WebAuth', function() {
         this.auth0.client.passwordless.start.restore();
       }
     });
-    it('should call `transactionManager.process` with merged params', function() {
+    it('should call `transactionManager.process` with merged params', function () {
       sinon
         .stub(this.auth0.client.passwordless, 'start')
-        .callsFake(function() {});
+        .callsFake(function () { });
       sinon.spy(TransactionManager.prototype, 'process');
       var expectedOptions = {
         responseType: 'code',
@@ -1933,7 +1933,7 @@ describe('auth0.WebAuth', function() {
             auth: 'params'
           }
         },
-        function(err, data) {
+        function (err, data) {
           return 'cb';
         }
       );
@@ -1941,7 +1941,7 @@ describe('auth0.WebAuth', function() {
       expect(mock.calledOnce).to.be(true);
       expect(mock.firstCall.args[0]).to.be.eql(expectedOptions);
     });
-    it('should call `passwordless.start` with params from transactionManager', function() {
+    it('should call `passwordless.start` with params from transactionManager', function () {
       var expectedOptions = {
         authParams: {
           from: 'transactionManager'
@@ -1949,20 +1949,20 @@ describe('auth0.WebAuth', function() {
       };
       var mockVerify = sinon
         .stub(this.auth0.client.passwordless, 'start')
-        .callsFake(function() {});
-      sinon.stub(TransactionManager.prototype, 'process').callsFake(function() {
+        .callsFake(function () { });
+      sinon.stub(TransactionManager.prototype, 'process').callsFake(function () {
         return expectedOptions.authParams;
       });
 
-      this.auth0.passwordlessStart({}, function(err, data) {
+      this.auth0.passwordlessStart({}, function (err, data) {
         return 'cb';
       });
       expect(mockVerify.calledOnce).to.be(true);
       expect(mockVerify.firstCall.args[0]).to.be.eql(expectedOptions);
     });
 
-    it('should call passwordless start sms with all the options', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call passwordless start sms with all the options', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/passwordless/start');
         return new RequestMock({
           body: {
@@ -1979,7 +1979,7 @@ describe('auth0.WebAuth', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(null, {
               body: {}
             });
@@ -1987,7 +1987,7 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      sinon.stub(TransactionManager.prototype, 'process').callsFake(function() {
+      sinon.stub(TransactionManager.prototype, 'process').callsFake(function () {
         return { from: 'tm' };
       });
 
@@ -1997,7 +1997,7 @@ describe('auth0.WebAuth', function() {
           phoneNumber: '123456',
           send: 'code'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({});
           done();
@@ -2005,8 +2005,8 @@ describe('auth0.WebAuth', function() {
       );
     });
 
-    it('should call passwordless start email with all the options', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call passwordless start email with all the options', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/passwordless/start');
         return new RequestMock({
           body: {
@@ -2023,7 +2023,7 @@ describe('auth0.WebAuth', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(null, {
               body: {}
             });
@@ -2031,7 +2031,7 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      sinon.stub(TransactionManager.prototype, 'process').callsFake(function() {
+      sinon.stub(TransactionManager.prototype, 'process').callsFake(function () {
         return { from: 'tm' };
       });
 
@@ -2041,7 +2041,7 @@ describe('auth0.WebAuth', function() {
           email: 'me@example.com',
           send: 'code'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({});
           done();
@@ -2050,8 +2050,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('passwordlessLogin', function() {
-    beforeEach(function() {
+  context('passwordlessLogin', function () {
+    beforeEach(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2060,9 +2060,9 @@ describe('auth0.WebAuth', function() {
         _sendTelemetry: false
       });
     });
-    context('when outside of the universal login page', function() {
-      beforeEach(function() {
-        sinon.stub(windowHelper, 'getWindow').callsFake(function() {
+    context('when outside of the universal login page', function () {
+      beforeEach(function () {
+        sinon.stub(windowHelper, 'getWindow').callsFake(function () {
           return {
             location: {
               host: 'other-domain.auth0.com'
@@ -2071,7 +2071,7 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         windowHelper.getWindow.restore();
         if (CrossOriginAuthentication.prototype.login.restore) {
           CrossOriginAuthentication.prototype.login.restore();
@@ -2080,7 +2080,7 @@ describe('auth0.WebAuth', function() {
           CrossOriginAuthentication.prototype.callback.restore();
         }
       });
-      it('should call `crossOriginAuthentication.login` with phoneNumber', function(done) {
+      it('should call `crossOriginAuthentication.login` with phoneNumber', function (done) {
         var expectedOptions = {
           credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
           realm: 'sms',
@@ -2094,7 +2094,7 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(CrossOriginAuthentication.prototype, 'login')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
@@ -2106,12 +2106,12 @@ describe('auth0.WebAuth', function() {
             phoneNumber: '+55165134',
             verificationCode: '123456'
           },
-          function(err, data) {
+          function (err, data) {
             return 'cb';
           }
         );
       });
-      it('should call `crossOriginAuthentication.login` with email', function(done) {
+      it('should call `crossOriginAuthentication.login` with email', function (done) {
         var expectedOptions = {
           credentialType: 'http://auth0.com/oauth/grant-type/passwordless/otp',
           realm: 'email',
@@ -2125,7 +2125,7 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(CrossOriginAuthentication.prototype, 'login')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
@@ -2137,15 +2137,15 @@ describe('auth0.WebAuth', function() {
             email: 'the@email.com',
             verificationCode: '123456'
           },
-          function(err, data) {
+          function (err, data) {
             return 'cb';
           }
         );
       });
     });
-    context('when inside of the universal login page', function() {
-      beforeEach(function() {
-        sinon.stub(windowHelper, 'getWindow').callsFake(function() {
+    context('when inside of the universal login page', function () {
+      beforeEach(function () {
+        sinon.stub(windowHelper, 'getWindow').callsFake(function () {
           return {
             location: {
               host: 'me.auth0.com'
@@ -2154,10 +2154,10 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         windowHelper.getWindow.restore();
       });
-      it('should call `webauth.passwordlessVerify` with phoneNumber', function(done) {
+      it('should call `webauth.passwordlessVerify` with phoneNumber', function (done) {
         var expectedOptions = {
           clientID: '...',
           responseType: 'id_token',
@@ -2170,7 +2170,7 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(this.auth0, 'passwordlessVerify')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
@@ -2182,12 +2182,12 @@ describe('auth0.WebAuth', function() {
             phoneNumber: '+55165134',
             verificationCode: '123456'
           },
-          function(err, data) {
+          function (err, data) {
             return 'cb';
           }
         );
       });
-      it('should call `webauth.passwordlessVerify` with email', function(done) {
+      it('should call `webauth.passwordlessVerify` with email', function (done) {
         var expectedOptions = {
           clientID: '...',
           responseType: 'id_token',
@@ -2200,7 +2200,7 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(this.auth0, 'passwordlessVerify')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
@@ -2212,7 +2212,7 @@ describe('auth0.WebAuth', function() {
             email: 'the@email.com',
             verificationCode: '123456'
           },
-          function(err, data) {
+          function (err, data) {
             return 'cb';
           }
         );
@@ -2220,8 +2220,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('passwordlessVerify', function() {
-    beforeEach(function() {
+  context('passwordlessVerify', function () {
+    beforeEach(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2230,11 +2230,11 @@ describe('auth0.WebAuth', function() {
         _sendTelemetry: false
       });
     });
-    afterEach(function() {
+    afterEach(function () {
       TransactionManager.prototype.process.restore();
       this.auth0.client.passwordless.verify.restore();
     });
-    it('should validate params', function() {
+    it('should validate params', function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2244,16 +2244,16 @@ describe('auth0.WebAuth', function() {
       });
       sinon
         .stub(this.auth0.client.passwordless, 'verify')
-        .callsFake(function() {});
+        .callsFake(function () { });
       sinon.spy(TransactionManager.prototype, 'process');
       expect(() => this.auth0.passwordlessVerify({})).to.throwError(
         /responseType option is required/
       );
     });
-    it('should call `transactionManager.process` with merged params', function() {
+    it('should call `transactionManager.process` with merged params', function () {
       sinon
         .stub(this.auth0.client.passwordless, 'verify')
-        .callsFake(function() {});
+        .callsFake(function () { });
       sinon.spy(TransactionManager.prototype, 'process');
       var expectedOptions = {
         clientID: '...',
@@ -2271,7 +2271,7 @@ describe('auth0.WebAuth', function() {
           phoneNumber: '+55165134',
           verificationCode: '123456'
         },
-        function(err, data) {
+        function (err, data) {
           return 'cb';
         }
       );
@@ -2279,56 +2279,56 @@ describe('auth0.WebAuth', function() {
       expect(mock.calledOnce).to.be(true);
       expect(mock.firstCall.args[0]).to.be.eql(expectedOptions);
     });
-    it('should call `passwordless.verify` with params from transactionManager', function() {
+    it('should call `passwordless.verify` with params from transactionManager', function () {
       var expectedOptions = {
         from: 'transactionManager'
       };
       var mockVerify = sinon
         .stub(this.auth0.client.passwordless, 'verify')
-        .callsFake(function() {});
-      sinon.stub(TransactionManager.prototype, 'process').callsFake(function() {
+        .callsFake(function () { });
+      sinon.stub(TransactionManager.prototype, 'process').callsFake(function () {
         return expectedOptions;
       });
 
-      this.auth0.passwordlessVerify({}, function(err, data) {
+      this.auth0.passwordlessVerify({}, function (err, data) {
         return 'cb';
       });
       expect(mockVerify.calledOnce).to.be(true);
       expect(mockVerify.firstCall.args[0]).to.be.eql(expectedOptions);
     });
-    it('should call callback with error', function(done) {
+    it('should call callback with error', function (done) {
       var expectedError = new Error('some error');
       sinon
         .stub(this.auth0.client.passwordless, 'verify')
-        .callsFake(function(params, cb) {
+        .callsFake(function (params, cb) {
           cb(expectedError);
         });
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function() {});
+        .callsFake(function () { });
 
-      this.auth0.passwordlessVerify({}, function(err, data) {
+      this.auth0.passwordlessVerify({}, function (err, data) {
         expect(err).to.be.eql(expectedError);
         done();
       });
     });
-    it('should windowHelper.redirect on success', function(done) {
+    it('should windowHelper.redirect on success', function (done) {
       var expectedUrl = 'https://verify-url.example.com';
 
       sinon
         .stub(this.auth0.client.passwordless, 'buildVerifyUrl')
-        .callsFake(function() {
+        .callsFake(function () {
           return expectedUrl;
         });
       sinon
         .stub(this.auth0.client.passwordless, 'verify')
-        .callsFake(function(params, cb) {
+        .callsFake(function (params, cb) {
           cb(null);
         });
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function() {});
-      sinon.stub(windowHelper, 'redirect').callsFake(function(url) {
+        .callsFake(function () { });
+      sinon.stub(windowHelper, 'redirect').callsFake(function (url) {
         expect(url).to.be(expectedUrl);
         done();
       });
@@ -2340,8 +2340,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('signup', function() {
-    before(function() {
+  context('signup', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2351,12 +2351,12 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       request.post.restore();
     });
 
-    it('should call db-connection signup with all the options', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call db-connection signup with all the options', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         if (url === 'https://me.auth0.com/oauth/token') {
           return new RequestMock({
             body: {
@@ -2370,7 +2370,7 @@ describe('auth0.WebAuth', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   token_type: 'Bearer',
@@ -2393,7 +2393,7 @@ describe('auth0.WebAuth', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   _id: '...',
@@ -2415,14 +2415,14 @@ describe('auth0.WebAuth', function() {
           password: '123456',
           scope: 'openid'
         },
-        function(err, data) {
+        function (err, data) {
           done();
         }
       );
     });
 
-    it('should propagate signup errors', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should propagate signup errors', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/dbconnections/signup');
 
         return new RequestMock({
@@ -2435,7 +2435,7 @@ describe('auth0.WebAuth', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb({
               response: {
                 statusCode: 400,
@@ -2456,7 +2456,7 @@ describe('auth0.WebAuth', function() {
           password: '123456',
           scope: 'openid'
         },
-        function(err, data) {
+        function (err, data) {
           expect(data).to.be(undefined);
           expect(err).to.eql({
             original: {
@@ -2478,9 +2478,9 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('login', function() {
-    context('when outside of the universal login page', function() {
-      before(function() {
+  context('login', function () {
+    context('when outside of the universal login page', function () {
+      before(function () {
         this.auth0 = new WebAuth({
           domain: 'me.auth0.com',
           clientID: '...',
@@ -2489,8 +2489,8 @@ describe('auth0.WebAuth', function() {
           _sendTelemetry: false
         });
       });
-      beforeEach(function() {
-        sinon.stub(windowHelper, 'getWindow').callsFake(function() {
+      beforeEach(function () {
+        sinon.stub(windowHelper, 'getWindow').callsFake(function () {
           return {
             location: {
               host: 'other-domain.auth0.com'
@@ -2499,12 +2499,12 @@ describe('auth0.WebAuth', function() {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         windowHelper.getWindow.restore();
         CrossOriginAuthentication.prototype.login.restore();
       });
 
-      it('should call CrossOriginAuthentication.login', function(done) {
+      it('should call CrossOriginAuthentication.login', function (done) {
         var expectedOptions = {
           clientID: '...',
           responseType: 'token',
@@ -2514,18 +2514,18 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(CrossOriginAuthentication.prototype, 'login')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
           });
-        this.auth0.login(expectedOptions, function() {
+        this.auth0.login(expectedOptions, function () {
           return 'cb';
         });
       });
     });
-    context('when inside of the universal login page', function() {
-      before(function() {
+    context('when inside of the universal login page', function () {
+      before(function () {
         this.auth0 = new WebAuth({
           domain: 'me.auth0.com',
           clientID: '...',
@@ -2534,8 +2534,8 @@ describe('auth0.WebAuth', function() {
           _sendTelemetry: false
         });
       });
-      beforeEach(function() {
-        sinon.stub(windowHelper, 'getWindow').callsFake(function() {
+      beforeEach(function () {
+        sinon.stub(windowHelper, 'getWindow').callsFake(function () {
           return {
             location: {
               host: 'me.auth0.com'
@@ -2543,10 +2543,10 @@ describe('auth0.WebAuth', function() {
           };
         });
       });
-      afterEach(function() {
+      afterEach(function () {
         windowHelper.getWindow.restore();
       });
-      it('calls _hostedPages.login mapping the connection parameter', function(done) {
+      it('calls _hostedPages.login mapping the connection parameter', function (done) {
         var expectedOptions = {
           clientID: '...',
           responseType: 'token',
@@ -2556,20 +2556,20 @@ describe('auth0.WebAuth', function() {
         };
         sinon
           .stub(HostedPages.prototype, 'login')
-          .callsFake(function(options, cb) {
+          .callsFake(function (options, cb) {
             expect(options).to.be.eql(expectedOptions);
             expect(cb()).to.be('cb');
             done();
           });
-        this.auth0.login({ realm: 'bar' }, function() {
+        this.auth0.login({ realm: 'bar' }, function () {
           return 'cb';
         });
       });
     });
   });
 
-  context('cross origin callbacks', function() {
-    before(function() {
+  context('cross origin callbacks', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2579,16 +2579,16 @@ describe('auth0.WebAuth', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       CrossOriginAuthentication.prototype.callback.restore();
     });
-    it('should call callback with deprecated method `crossOriginAuthenticationCallback`', function(done) {
+    it('should call callback with deprecated method `crossOriginAuthenticationCallback`', function (done) {
       sinon
         .stub(CrossOriginAuthentication.prototype, 'callback')
         .callsFake(done);
       this.auth0.crossOriginAuthenticationCallback();
     });
-    it('should call callback', function(done) {
+    it('should call callback', function (done) {
       sinon
         .stub(CrossOriginAuthentication.prototype, 'callback')
         .callsFake(done);
@@ -2596,8 +2596,8 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('checkSession', function() {
-    beforeEach(function() {
+  context('checkSession', function () {
+    beforeEach(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -2607,20 +2607,20 @@ describe('auth0.WebAuth', function() {
       });
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(params) {
+        .callsFake(function (params) {
           return Object.assign({}, params, { from: 'transaction-manager' });
         });
       sinon
         .stub(TransactionManager.prototype, 'clearTransaction')
-        .callsFake(function() {});
-      sinon.stub(windowHelper, 'getOrigin').callsFake(function() {
+        .callsFake(function () { });
+      sinon.stub(windowHelper, 'getOrigin').callsFake(function () {
         return 'https://test-origin.com';
       });
-      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function() {
+      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function () {
         return 'https://test-origin.com';
       });
     });
-    afterEach(function() {
+    afterEach(function () {
       TransactionManager.prototype.process.restore();
       TransactionManager.prototype.clearTransaction.restore();
       if (IframeHandler.prototype.init.restore) {
@@ -2638,39 +2638,39 @@ describe('auth0.WebAuth', function() {
       windowHelper.getOrigin.restore();
       objectHelper.getOriginFromUrl.restore();
     });
-    it('throws an error if responseType is code', function() {
-      this.auth0.checkSession({ responseType: 'code' }, function(err) {
+    it('throws an error if responseType is code', function () {
+      this.auth0.checkSession({ responseType: 'code' }, function (err) {
         expect(err).to.be.eql({
           error: 'error',
           error_description: "responseType can't be `code`"
         });
       });
     });
-    it('throws an error if redirectUri is empty', function() {
-      this.auth0.checkSession({ redirectUri: '' }, function(err) {
+    it('throws an error if redirectUri is empty', function () {
+      this.auth0.checkSession({ redirectUri: '' }, function (err) {
         expect(err).to.be.eql({
           error: 'error',
           error_description: "redirectUri can't be empty"
         });
       });
     });
-    it('does not throw an origin_mismatch error if redirectUri is empty', function() {
+    it('does not throw an origin_mismatch error if redirectUri is empty', function () {
       objectHelper.getOriginFromUrl.restore();
-      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function() {
+      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function () {
         return undefined;
       });
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {});
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () { });
 
-      this.auth0.checkSession({}, function(err) {
+      this.auth0.checkSession({}, function (err) {
         expect(err).to.be.eql(undefined);
       });
     });
-    it('throws an error if there is an origin mismatch between current window and redirectUri', function() {
+    it('throws an error if there is an origin mismatch between current window and redirectUri', function () {
       objectHelper.getOriginFromUrl.restore();
-      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function() {
+      sinon.stub(objectHelper, 'getOriginFromUrl').callsFake(function () {
         return 'some-other-origin';
       });
-      this.auth0.checkSession({}, function(err) {
+      this.auth0.checkSession({}, function (err) {
         expect(err).to.be.eql({
           original: {
             error: 'origin_mismatch',
@@ -2686,8 +2686,8 @@ describe('auth0.WebAuth', function() {
         });
       });
     });
-    it('inits IframeHandler with correct params', function(done) {
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+    it('inits IframeHandler with correct params', function (done) {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         expect(this.url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&from=transaction-manager&response_mode=web_message&prompt=none'
         );
@@ -2695,11 +2695,11 @@ describe('auth0.WebAuth', function() {
         expect(this.timeout).to.be(60000);
         done();
       });
-      this.auth0.checkSession({}, function(err, data) {});
+      this.auth0.checkSession({}, function (err, data) { });
     });
-    it('uses custom timeout when provided', function(done) {
+    it('uses custom timeout when provided', function (done) {
       var timeout = 1;
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         expect(this.timeout).to.be(timeout);
         done();
       });
@@ -2707,12 +2707,12 @@ describe('auth0.WebAuth', function() {
         {
           timeout: timeout
         },
-        function(err, data) {}
+        function (err, data) { }
       );
     });
-    it('eventValidator validates the event data type is `authorization_response` and the state matches the transaction state', function(done) {
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
-        var getEvent = function(type, state) {
+    it('eventValidator validates the event data type is `authorization_response` and the state matches the transaction state', function (done) {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
+        var getEvent = function (type, state) {
           return {
             event: { data: { type: type, response: { state: state } } }
           };
@@ -2733,13 +2733,13 @@ describe('auth0.WebAuth', function() {
         ).to.be(true);
         done();
       });
-      this.auth0.checkSession({ state: '123' }, function(err, data) {});
+      this.auth0.checkSession({ state: '123' }, function (err, data) { });
     });
-    it('timeoutCallback calls callback with error response', function(done) {
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+    it('timeoutCallback calls callback with error response', function (done) {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.timeoutCallback();
       });
-      this.auth0.checkSession({ state: 'foobar' }, function(err, data) {
+      this.auth0.checkSession({ state: 'foobar' }, function (err, data) {
         expect(err).to.be.eql({
           original: {
             error: 'timeout',
@@ -2755,16 +2755,16 @@ describe('auth0.WebAuth', function() {
         done();
       });
     });
-    it('callback handles error response', function(done) {
+    it('callback handles error response', function (done) {
       var errorResponse = {
         error: 'the-error',
         error_description: 'error description',
         somethingElse: 'foobar'
       };
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.callback({ event: { data: { response: errorResponse } } });
       });
-      this.auth0.checkSession({}, function(err, data) {
+      this.auth0.checkSession({}, function (err, data) {
         expect(err).to.be.eql({
           original: {
             error: 'the-error',
@@ -2778,41 +2778,41 @@ describe('auth0.WebAuth', function() {
         done();
       });
     });
-    it('callback clears transaction on error response', function(done) {
+    it('callback clears transaction on error response', function (done) {
       var errorResponse = {
         error: 'the-error',
         error_description: 'error description',
         state: 'foobar'
       };
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.callback({ event: { data: { response: errorResponse } } });
       });
-      this.auth0.checkSession({}, function(err, data) {
+      this.auth0.checkSession({}, function (err, data) {
         expect(
           TransactionManager.prototype.clearTransaction.firstCall.args[0]
         ).to.be(errorResponse.state);
         done();
       });
     });
-    it('callback clears transaction on timeout', function(done) {
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+    it('callback clears transaction on timeout', function (done) {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.timeoutCallback();
       });
-      this.auth0.checkSession({ state: 'foobar' }, function(err, data) {
+      this.auth0.checkSession({ state: 'foobar' }, function (err, data) {
         expect(
           TransactionManager.prototype.clearTransaction.firstCall.args[0]
         ).to.be('foobar');
         done();
       });
     });
-    it('callback writes to console when consent_required + hostname===localhost', function(done) {
+    it('callback writes to console when consent_required + hostname===localhost', function (done) {
       var errorResponse = {
         error: 'consent_required'
       };
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.callback({ event: { data: { response: errorResponse } } });
       });
-      sinon.stub(windowHelper, 'getWindow').callsFake(function() {
+      sinon.stub(windowHelper, 'getWindow').callsFake(function () {
         return {
           location: {
             hostname: 'localhost'
@@ -2820,21 +2820,21 @@ describe('auth0.WebAuth', function() {
         };
       });
       var warnings = [];
-      sinon.stub(Warn.prototype, 'warning').callsFake(function(e) {
+      sinon.stub(Warn.prototype, 'warning').callsFake(function (e) {
         warnings.push(e);
       });
-      this.auth0.checkSession({}, function() {
+      this.auth0.checkSession({}, function () {
         expect(warnings[1]).to.be(
           "Consent Required. Consent can't be skipped on localhost. Read more here: https://auth0.com/docs/api-auth/user-consent#skipping-consent-for-first-party-clients"
         );
         done();
       });
     });
-    it('callback handles success response', function(done) {
+    it('callback handles success response', function (done) {
       var response = { access_token: 'foobar' };
       sinon
         .stub(WebAuth.prototype, 'validateAuthenticationResponse')
-        .callsFake(function(options, parsedHash, cb) {
+        .callsFake(function (options, parsedHash, cb) {
           expect(options).to.be.eql({
             clientID: '...',
             responseType: 'token',
@@ -2848,16 +2848,16 @@ describe('auth0.WebAuth', function() {
             accessToken: response.access_token
           });
         });
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.callback({ event: { data: { response: response } } });
       });
-      this.auth0.checkSession({}, function(err, data) {
+      this.auth0.checkSession({}, function (err, data) {
         expect(err).to.be(null);
         expect(data).to.be.eql({ accessToken: 'foobar' });
         done();
       });
     });
-    it('callback handles success response without changing idTokenPayload casing', function(done) {
+    it('callback handles success response without changing idTokenPayload casing', function (done) {
       var response = {
         access_token: 'foobar',
         idTokenPayload: {
@@ -2866,16 +2866,16 @@ describe('auth0.WebAuth', function() {
       };
       sinon
         .stub(WebAuth.prototype, 'validateAuthenticationResponse')
-        .callsFake(function(options, parsedHash, cb) {
+        .callsFake(function (options, parsedHash, cb) {
           cb(null, {
             accessToken: response.access_token,
             idTokenPayload: response.idTokenPayload
           });
         });
-      sinon.stub(IframeHandler.prototype, 'init').callsFake(function() {
+      sinon.stub(IframeHandler.prototype, 'init').callsFake(function () {
         this.callback({ event: { data: { response: response } } });
       });
-      this.auth0.checkSession({}, function(err, data) {
+      this.auth0.checkSession({}, function (err, data) {
         expect(err).to.be(null);
         expect(data).to.be.eql({
           accessToken: 'foobar',
@@ -2886,9 +2886,9 @@ describe('auth0.WebAuth', function() {
     });
   });
 
-  context('validateToken', function() {
-    it('should send through a default leeway', function(done) {
-      var idTokenVerifierMock = function(opts) {
+  context('validateToken', function () {
+    it('should send through a default leeway', function (done) {
+      var idTokenVerifierMock = function (opts) {
         expect(opts.leeway).to.be(60);
         done();
       };
@@ -2904,11 +2904,11 @@ describe('auth0.WebAuth', function() {
         responseType: 'token id_token'
       });
 
-      webAuth.validateToken('token', 'nonce', function() {});
+      webAuth.validateToken('token', 'nonce', function () { });
     });
 
-    it('should accept a specified leeway', function(done) {
-      var idTokenVerifierMock = function(opts) {
+    it('should accept a specified leeway', function (done) {
+      var idTokenVerifierMock = function (opts) {
         expect(opts.leeway).to.be(25);
         done();
       };
@@ -2925,11 +2925,11 @@ describe('auth0.WebAuth', function() {
         leeway: 25
       });
 
-      webAuth.validateToken('token', 'nonce', function() {});
+      webAuth.validateToken('token', 'nonce', function () { });
     });
 
-    it('should use undefined jwksURI, allowing it to be overwritten later', function(done) {
-      var idTokenVerifierMock = function(opts) {
+    it('should use undefined jwksURI, allowing it to be overwritten later', function (done) {
+      var idTokenVerifierMock = function (opts) {
         expect(opts.jwksURI).to.be(undefined);
         done();
       };
@@ -2943,11 +2943,11 @@ describe('auth0.WebAuth', function() {
         responseType: 'token id_token'
       });
 
-      webAuth.validateToken('token', 'nonce', function() {});
+      webAuth.validateToken('token', 'nonce', function () { });
     });
 
-    it('should use correct jwksURI when overriden', function(done) {
-      var idTokenVerifierMock = function(opts) {
+    it('should use correct jwksURI when overriden', function (done) {
+      var idTokenVerifierMock = function (opts) {
         expect(opts.jwksURI).to.be('jwks_uri');
         done();
       };
@@ -2963,7 +2963,37 @@ describe('auth0.WebAuth', function() {
           __jwks_uri: 'jwks_uri'
         }
       });
-      webAuth.validateToken('token', 'nonce', function() {});
+      webAuth.validateToken('token', 'nonce', function () { });
     });
+  });
+
+  context('captcha rendering', function () {
+    it('should call the captcha rendering function', function () {
+      const element = {};
+      const options = {};
+      const captcha = {};
+      const renderStub = sinon.stub().returns(captcha);
+      const callback = function () { };
+
+      var { default: ProxiedWebAuth } = proxyquire('../../src/web-auth', {
+        './captcha': { default: { render: renderStub } }
+      });
+
+      var webAuth = new ProxiedWebAuth({
+        domain: 'brucke.auth0.com',
+        redirectUri: 'http://example.com/callback',
+        clientID: 'k5u3o2fiAA8XweXEEX604KCwCjzjtMU6',
+      });
+
+      const result = webAuth.renderCaptcha(element, options, callback);
+
+      expect(renderStub.called).to.be.ok();
+      expect(renderStub.args[0][0]).to.be.equal(webAuth.client);
+      expect(renderStub.args[0][1]).to.be.equal(element);
+      expect(renderStub.args[0][2]).to.be.equal(options);
+      expect(renderStub.args[0][3]).to.be.equal(callback);
+      expect(result).to.equal(captcha);
+    });
+
   });
 });


### PR DESCRIPTION
### Changes

I am adding a new method to this library as part of improving the support for captcha in custom login pages for classic Universal Login. This method allow with a single line to render the captcha in an html element.

The template can be customised but the provided by default will be enough for a lot of use cases.

### References

https://auth0team.atlassian.net/browse/CAUTH-551

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested in vivaldi

![image](https://user-images.githubusercontent.com/178512/92240846-a095da80-ee93-11ea-99fb-b06eb2a70b46.png)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
