### PR TITLE
Use npm instead of yarn in Jenkins CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,21 +201,21 @@ If you need help migrating to v8, please refer to the [v8 Migration Guide](https
 
 ## Develop
 
-Run `yarn install` to set up the environment.
+Run `npm install` to set up the environment.
 
-Run `yarn start` to point your browser to [`https://localhost:3000/`](https://localhost:3000/) to verify the example page works.
+Run `npm start` to point your browser to [`https://localhost:3000/`](https://localhost:3000/) to verify the example page works.
 
-Run `yarn test` to run the test suite.
+Run `npm test` to run the test suite.
 
-Run `yarn ci:test` to run the tests that ci runs.
+Run `npm run ci:test` to run the tests that ci runs.
 
-Run `yarn test:watch` to run the test suite while you work.
+Run `npm run test:watch` to run the test suite while you work.
 
-Run `yarn test:coverage` to run the test suite with coverage report.
+Run `npm run test:coverage` to run the test suite with coverage report.
 
-Run `yarn lint` to run the linter and check code styles.
+Run `npm run lint` to run the linter and check code styles.
 
-Run `yarn install && yarn build && yarn test:es-check:es5 && yarn test:es-check:es2015:module` to check for JS incompatibility.
+Run `npm install && npm run build && npm run test:es-check:es5 && npm run test:es-check:es2015:module` to check for JS incompatibility.
 
 See [.circleci/config.yml](.circleci/config.yml) for additional checks that might be run as part of
 [circleci integration tests](https://circleci.com/).
@@ -246,6 +246,5 @@ This project is licensed under the MIT license. See the [LICENSE](LICENSE) file 
 [license-url]: #license
 [downloads-image]: https://img.shields.io/npm/dm/auth0-js.svg?style=flat-square
 [downloads-url]: https://npmjs.org/package/auth0-js
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Fauth0.js.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Fauth0.js?ref=badge_large)

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-yarn install
+npm install
 
 NPM_TAG=${2:-"beta"}
 MATCHER=${3:-"*"}
@@ -88,17 +88,17 @@ npm_release()
 }
 
 # Lint
-yarn run lint
+npm run lint
 
 # Test
-yarn run ci:test
+npm run ci:test
 
 # Clean
 rm -rf dist
 rm -rf build
 
 # Build
-yarn run build
+npm run build
 
 # Release
 git checkout -b dist


### PR DESCRIPTION
### Changes

This fixes the CI on Jenkins so that it builds using npm over yarn.

The build isn't currently broken, but this ensures that it uses the correct lock file for the build.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
