### PR TITLE
Allow domain to contain http scheme

### DIFF
--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -78,7 +78,12 @@ function Authentication(auth0, options) {
         optional: true,
         type: 'object',
         message: '_telemetryInfo option is not valid'
-      }
+      },
+      domainScheme: {
+        optional: true,
+        type: 'string',
+        message: 'domainScheme is not valid'
+      },
     }
   );
   /* eslint-enable */
@@ -88,8 +93,9 @@ function Authentication(auth0, options) {
     this.baseOptions._sendTelemetry === false
       ? this.baseOptions._sendTelemetry
       : true;
-
-  this.baseOptions.rootUrl = 'https://' + this.baseOptions.domain;
+  
+  this.baseOptions.domainScheme = !this.baseOptions.domainScheme ? 'https://' : this.baseOptions.domainScheme
+  this.baseOptions.rootUrl = this.baseOptions.domainScheme + this.baseOptions.domain;
 
   this.request = new RequestBuilder(this.baseOptions);
 

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -79,11 +79,6 @@ function Authentication(auth0, options) {
         type: 'object',
         message: '_telemetryInfo option is not valid'
       },
-      domainScheme: {
-        optional: true,
-        type: 'string',
-        message: 'domainScheme is not valid'
-      },
     }
   );
   /* eslint-enable */
@@ -94,8 +89,11 @@ function Authentication(auth0, options) {
       ? this.baseOptions._sendTelemetry
       : true;
   
-  this.baseOptions.domainScheme = !this.baseOptions.domainScheme ? 'https://' : this.baseOptions.domainScheme
-  this.baseOptions.rootUrl = this.baseOptions.domainScheme + this.baseOptions.domain;
+
+    
+  this.baseOptions.rootUrl = (this.baseOptions.domain && this.baseOptions.domain.toLowerCase().startsWith('http'))
+      ? this.baseOptions.domain
+      : 'https://' + this.baseOptions.domain;
 
   this.request = new RequestBuilder(this.baseOptions);
 

--- a/src/authentication/index.js
+++ b/src/authentication/index.js
@@ -89,12 +89,10 @@ function Authentication(auth0, options) {
       ? this.baseOptions._sendTelemetry
       : true;
   
-
-    
-  this.baseOptions.rootUrl = (this.baseOptions.domain && this.baseOptions.domain.toLowerCase().startsWith('http'))
+  this.baseOptions.rootUrl = (this.baseOptions.domain && this.baseOptions.domain.toLowerCase().indexOf('http') === 0)
       ? this.baseOptions.domain
       : 'https://' + this.baseOptions.domain;
-
+      
   this.request = new RequestBuilder(this.baseOptions);
 
   this.passwordless = new PasswordlessAuthentication(

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -32,15 +32,15 @@ describe('auth0.authentication', function() {
       var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid' });
       expect(auth0.baseOptions.domain).to.be.equal('foo');
     });
-    it('should set rootUrl using domain and domain schema, when two arguements are used', function() {
+    it('should set rootUrl using domain and domain scheme, when two arguements are used', function() {
       var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
       expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
     });
-    it('should set rootUrl using domain and domain schema, when one arguements is used', function() {
+    it('should set rootUrl using domain and domain scheme, when one arguements is used', function() {
       var auth0 = new Authentication({ domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
       expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
     });
-    it('should set prepend https:// to domain if domain schema is not set', function() {
+    it('should set prepend https:// to domain if domain scheme is not set', function() {
       var auth0 = new Authentication({ domain: 'foo', clientID: 'cid'  });
       expect(auth0.baseOptions.rootUrl).to.be.equal('https://foo');
     });

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -32,18 +32,19 @@ describe('auth0.authentication', function() {
       var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid' });
       expect(auth0.baseOptions.domain).to.be.equal('foo');
     });
-    it('should set rootUrl using domain and domain scheme, when two arguements are used', function() {
-      var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
-      expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
+    
+    [
+      {domain: 'https://foo', expectedRootUrl: 'https://foo'},
+      {domain: 'http://foo', expectedRootUrl: 'http://foo'},
+      {domain: 'HTTPS://FOO', expectedRootUrl: 'HTTPS://FOO'},
+      {domain: 'foo', expectedRootUrl: 'https://foo'},
+    ].forEach(function(mockData) {
+      it(`should construct root url ${mockData.expectedRootUrl} when using domain ${mockData.domain}`, function() {
+        var auth0 = new Authentication({ domain: mockData.domain, clientID: 'cid'  });
+        expect(auth0.baseOptions.rootUrl).to.be.equal(mockData.expectedRootUrl);
+      });
     });
-    it('should set rootUrl using domain and domain scheme, when one arguements is used', function() {
-      var auth0 = new Authentication({ domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
-      expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
-    });
-    it('should set prepend https:// to domain if domain scheme is not set', function() {
-      var auth0 = new Authentication({ domain: 'foo', clientID: 'cid'  });
-      expect(auth0.baseOptions.rootUrl).to.be.equal('https://foo');
-    });
+
     it('should check that options is passed', function() {
       expect(function() {
         var auth0 = new Authentication();

--- a/test/authentication/authentication.test.js
+++ b/test/authentication/authentication.test.js
@@ -32,6 +32,18 @@ describe('auth0.authentication', function() {
       var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid' });
       expect(auth0.baseOptions.domain).to.be.equal('foo');
     });
+    it('should set rootUrl using domain and domain schema, when two arguements are used', function() {
+      var auth0 = new Authentication({}, { domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
+      expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
+    });
+    it('should set rootUrl using domain and domain schema, when one arguements is used', function() {
+      var auth0 = new Authentication({ domain: 'foo', clientID: 'cid', domainScheme: 'http://'  });
+      expect(auth0.baseOptions.rootUrl).to.be.equal('http://foo');
+    });
+    it('should set prepend https:// to domain if domain schema is not set', function() {
+      var auth0 = new Authentication({ domain: 'foo', clientID: 'cid'  });
+      expect(auth0.baseOptions.rootUrl).to.be.equal('https://foo');
+    });
     it('should check that options is passed', function() {
       expect(function() {
         var auth0 = new Authentication();


### PR DESCRIPTION
### Changes
- Add domain scheme as an optional parameter to Authentication.

### References

Resolves https://github.com/auth0/auth0.js/issues/1134

### Testing

- [X] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
