### PR TITLE
Document  optional params to WebAuth.signup

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -25,6 +25,11 @@ function DBConnection(request, options) {
  * @param {String} options.email user email address
  * @param {String} options.password user password
  * @param {String} [options.username] user desired username. Required if you use a database connection and you have enabled `Requires Username`
+ * @param {String} [options.given_name] The user's given name(s).
+ * @param {String} [options.family_name] The user's family name(s).
+ * @param {String} [options.name] The user's full name.
+ * @param {String} [options.nickname] The user's nickname.
+ * @param {String} [options.picture] A URI pointing to the user's picture.
  * @param {String} options.connection name of the connection where the user will be created
  * @param {Object} [options.user_metadata] additional signup attributes used for creating the user. Will be stored in `user_metadata`
  * @param {signUpCallback} cb

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -692,6 +692,11 @@ WebAuth.prototype.passwordlessStart = function(options, cb) {
  * @param {String} options.email user email address
  * @param {String} options.password user password
  * @param {String} options.connection name of the connection where the user will be created
+ * @param {String} [options.given_name] The user's given name(s).
+ * @param {String} [options.family_name] The user's family name(s).
+ * @param {String} [options.name] The user's full name.
+ * @param {String} [options.nickname] The user's nickname.
+ * @param {String} [options.picture] A URI pointing to the user's picture.
  * @param {signUpCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  */


### PR DESCRIPTION
### Changes

I add documentation on the `signup` method of both `WebAuth` and `DbConnection`, regarding optional parameters that can be passed:
- given_name
- family_name
- name
- nickname
- picture 

As far as I can tell, the code already supports these params, as well as the matching API endpoint

### Testing

These changes require no tests

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
