### PR TITLE
Feature/recaptcha enterprise cauth 965

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -11,7 +11,7 @@ var AUTH0_PROVIDER = 'auth0';
 var defaults = {
   lang: 'en',
   templates: {
-    [AUTH0_PROVIDER]: function (challenge) {
+    'auth0': function (challenge) {
       var message = challenge.type === 'code' ?
         'Enter the code shown above' :
         'Solve the formula shown above';
@@ -24,10 +24,10 @@ var defaults = {
         '  placeholder="' + message + '" />';
     }
     ,
-    [RECAPTCHA_V2_PROVIDER]: function () {
+    'recaptcha_v2': function () {
       return '<div class="recaptcha" ></div><input type="hidden" name="captcha" />';
     },
-    [RECAPTCHA_ENTERPRISE_PROVIDER]: function () {
+    'recaptcha_enterprise': function () {
       return '<div class="recaptcha" ></div><input type="hidden" name="captcha" />';
     }    
     ,
@@ -59,9 +59,9 @@ function globalForRecaptchaProvider(provider) {
 function scriptForRecaptchaProvider(provider, lang, callback) {
   switch (provider) {
     case RECAPTCHA_V2_PROVIDER:
-      return `https://www.google.com/recaptcha/api.js?hl=${lang}&onload=${callback}`;
+      return 'https://www.google.com/recaptcha/api.js?hl='+lang+'&onload='+callback;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
-      return `https://www.google.com/recaptcha/enterprise.js?render=explicit&hl=${lang}&onload=${callback}`;
+      return 'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl='+lang+'&onload='+callback;
     default:
       throw new Error('Unknown captcha provider');      
   }

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -51,6 +51,7 @@ function globalForRecaptchaProvider(provider) {
       return window.grecaptcha;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return window.grecaptcha.enterprise;
+    /* istanbul ignore next */      
     default:
       throw new Error('Unknown captcha provider');
   }
@@ -62,6 +63,7 @@ function scriptForRecaptchaProvider(provider, lang, callback) {
       return 'https://www.google.com/recaptcha/api.js?hl='+lang+'&onload='+callback;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return 'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl='+lang+'&onload='+callback;
+    /* istanbul ignore next */
     default:
       throw new Error('Unknown captcha provider');      
   }


### PR DESCRIPTION
### Changes

Support enterprise recaptcha provider in auth0.js

Enterprise recaptcha requires identical configuration to recaptcha v2 with very minor changes on how it's loaded.
Rewrote the test suite for recaptcha to easier test both integrations

### References

https://auth0team.atlassian.net/browse/CAUTH-965

PRs to ULP and lockjs

https://github.com/auth0/lock/pull/1986
https://github.com/auth0/universal-login-prompts/pull/1080


### Testing

Login with recaptcha_v2 always on should still work.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
