### PR TITLE
Feature/recaptcha enterprise cauth 965

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -11,7 +11,7 @@ var AUTH0_PROVIDER = 'auth0';
 var defaults = {
   lang: 'en',
   templates: {
-    [AUTH0_PROVIDER]: function (challenge) {
+    'auth0': function (challenge) {
       var message = challenge.type === 'code' ?
         'Enter the code shown above' :
         'Solve the formula shown above';
@@ -24,10 +24,10 @@ var defaults = {
         '  placeholder="' + message + '" />';
     }
     ,
-    [RECAPTCHA_V2_PROVIDER]: function () {
+    'recaptcha_v2': function () {
       return '<div class="recaptcha" ></div><input type="hidden" name="captcha" />';
     },
-    [RECAPTCHA_ENTERPRISE_PROVIDER]: function () {
+    'recaptcha_enterprise': function () {
       return '<div class="recaptcha" ></div><input type="hidden" name="captcha" />';
     }    
     ,
@@ -59,9 +59,9 @@ function globalForRecaptchaProvider(provider) {
 function scriptForRecaptchaProvider(provider, lang, callback) {
   switch (provider) {
     case RECAPTCHA_V2_PROVIDER:
-      return `https://www.google.com/recaptcha/api.js?hl=${lang}&onload=${callback}`;
+      return 'https://www.google.com/recaptcha/api.js?hl='+lang+'&onload='+callback;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
-      return `https://www.google.com/recaptcha/enterprise.js?render=explicit&hl=${lang}&onload=${callback}`;
+      return 'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl='+lang+'&onload='+callback;
     default:
       throw new Error('Unknown captcha provider');      
   }

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -51,6 +51,7 @@ function globalForRecaptchaProvider(provider) {
       return window.grecaptcha;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return window.grecaptcha.enterprise;
+    /* istanbul ignore next */      
     default:
       throw new Error('Unknown captcha provider');
   }
@@ -62,6 +63,7 @@ function scriptForRecaptchaProvider(provider, lang, callback) {
       return 'https://www.google.com/recaptcha/api.js?hl='+lang+'&onload='+callback;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return 'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl='+lang+'&onload='+callback;
+    /* istanbul ignore next */
     default:
       throw new Error('Unknown captcha provider');      
   }

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -76,7 +76,7 @@ function scriptForRecaptchaProvider(provider, lang, callback) {
       );
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return (
-        'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl=' +
+        'https://www.recaptcha.net/recaptcha/enterprise.js?render=explicit&hl=' +
         lang +
         '&onload=' +
         callback

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -69,14 +69,14 @@ function scriptForRecaptchaProvider(provider, lang, callback) {
   switch (provider) {
     case RECAPTCHA_V2_PROVIDER:
       return (
-        'https://www.google.com/recaptcha/api.js?hl=' +
+        'https://www.recaptcha.net/recaptcha/api.js?hl=' +
         lang +
         '&onload=' +
         callback
       );
     case RECAPTCHA_ENTERPRISE_PROVIDER:
       return (
-        'https://www.google.com/recaptcha/enterprise.js?render=explicit&hl=' +
+        'https://www.recaptcha.net/recaptcha/enterprise.js?render=explicit&hl=' +
         lang +
         '&onload=' +
         callback

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -180,12 +180,23 @@ describe('captcha rendering', function () {
   const RECAPTCHA_ENTERPRISE_PROVIDER = 'recaptcha_enterprise';
 
   [RECAPTCHA_V2_PROVIDER,RECAPTCHA_ENTERPRISE_PROVIDER].forEach(provider => {
-    const getScript = () => {
+
+    const hostName = () => {
       switch(provider) {
-        case RECAPTCHA_V2_PROVIDER: return 'api.js';
-        case RECAPTCHA_ENTERPRISE_PROVIDER: return 'enterprise.js';
+        case RECAPTCHA_V2_PROVIDER: return 'www.google.com';
+        case RECAPTCHA_ENTERPRISE_PROVIDER: return 'www.recaptcha.net';
       }
     }
+
+    const pathName = () => {
+      switch(provider) {
+        case RECAPTCHA_V2_PROVIDER: return '/recaptcha/api.js';
+        case RECAPTCHA_ENTERPRISE_PROVIDER: return '/recaptcha/enterprise.js';
+      }
+    }
+
+    const getScript = () => `https://${hostName()}${pathName()}`;
+
     const setMockGlobal = (mock) => {
       switch(provider) {
         case RECAPTCHA_V2_PROVIDER: 
@@ -215,7 +226,7 @@ describe('captcha rendering', function () {
           }
         };
         c = captcha.render(mockClient, element);
-        recaptchaScript = [...window.document.querySelectorAll('script')].find(s => s.src.match('google\.com'));
+        recaptchaScript = [...window.document.querySelectorAll('script')].find(s => s.src.match(getScript()));
         scriptOnLoadCallback = window[url.parse(recaptchaScript.src, true).query.onload];
       });
   
@@ -226,8 +237,8 @@ describe('captcha rendering', function () {
       it('should inject the recaptcha script', function () {
         expect(recaptchaScript.async).to.be.ok();
         const scriptUrl = url.parse(recaptchaScript.src, true);
-        expect(scriptUrl.hostname).to.equal('www.google.com');
-        expect(scriptUrl.pathname).to.equal(`/recaptcha/${getScript()}`);
+        expect(scriptUrl.hostname).to.equal(hostName());
+        expect(scriptUrl.pathname).to.equal(pathName());
         expect(scriptUrl.query.hl).to.equal('en');
         expect(scriptUrl.query).to.have.property('onload');
       });

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -215,7 +215,7 @@ describe('captcha rendering', function () {
           }
         };
         c = captcha.render(mockClient, element);
-        recaptchaScript = [...window.document.querySelectorAll('script')].find(s => s.src.match('google\.com'));
+        recaptchaScript = [...window.document.querySelectorAll('script')].find(s => s.src.match('recaptcha.net'));
         scriptOnLoadCallback = window[url.parse(recaptchaScript.src, true).query.onload];
       });
   
@@ -226,7 +226,7 @@ describe('captcha rendering', function () {
       it('should inject the recaptcha script', function () {
         expect(recaptchaScript.async).to.be.ok();
         const scriptUrl = url.parse(recaptchaScript.src, true);
-        expect(scriptUrl.hostname).to.equal('www.google.com');
+        expect(scriptUrl.hostname).to.equal('www.recaptcha.net');
         expect(scriptUrl.pathname).to.equal(`/recaptcha/${getScript()}`);
         expect(scriptUrl.query.hl).to.equal('en');
         expect(scriptUrl.query).to.have.property('onload');


### PR DESCRIPTION
### Changes

Change URL used to render recaptcha (v2 and enterprise) widgets from google.com to recaptcha.net

It is preferred to use recaptcha.net when google.com is unavailable (i.e. for use in countries where the google.com domain is blocked).

This is done in universal-login-prompts in this approved PR https://github.com/auth0/universal-login-prompts/pull/1080/files#r616729196

### References

https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
https://auth0team.atlassian.net/browse/CAUTH-965


### Testing

Same as testing required for https://github.com/auth0/auth0.js/pull/1169

1. Enable Always on Captcha in the Dashboard under Security -> Bot Detection -> Captcha -> Always On
2. Enable Google ReCaptcha (reach out if you need a site key and secret, you can get free ones here - https://www.google.com/recaptcha/admin. Remember to select v2).
3. Run the auth0js SDK locally
4. Update your universal login template to point to the locally served auth0js sdk:
  - Go to Branding -> Universal Login and Select Classic
  - Click the Login tab and select Customize Login Page
  - Select the Lock template and change the auth0.min.js script src to `http://localhost:3000/auth0.js`


- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
