### PR TITLE
Update idtoken-verifier to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-js",
-  "version": "9.16.0",
+  "version": "9.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2453,9 +2453,9 @@
       "dev": true
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
     },
     "cssom": {
       "version": "0.4.4",
@@ -4412,12 +4412,12 @@
       }
     },
     "idtoken-verifier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.1.tgz",
-      "integrity": "sha512-nUdRiU6GOH7MOtpOK6WJTGftoFzviVraSaLi+KKwp+K7hu+PUpvxfCwOOvzKBqzJ78b+nL1qfyzkjbvrMYQ4Xw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/idtoken-verifier/-/idtoken-verifier-2.1.2.tgz",
+      "integrity": "sha512-YMHiP9zAMjB+pWreV4EHnIj3XCQ168+InWirVRFeRtlsMQIK61S+LLnyLGI8EL0wtlk/v7ya69Gjfio3P9/7Gw==",
       "requires": {
         "base64-js": "^1.3.0",
-        "crypto-js": "^4.0.0",
+        "crypto-js": "3.3.0",
         "es6-promise": "^4.2.8",
         "jsbn": "^1.1.0",
         "unfetch": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "base64-js": "^1.3.0",
-    "idtoken-verifier": "^2.1.1",
+    "idtoken-verifier": "^2.1.2",
     "js-cookie": "^2.2.0",
     "qs": "^6.7.0",
     "superagent": "^5.3.1",


### PR DESCRIPTION
### Changes

This PR updates to `idtoken-verifier@2.1.2` to fix an issue in
`crypto-js@4.0.0` that requires a native Crypto module to be present. This
effectively reverts to `crypto-js@3.3.0` while we determine a long-term fix.

### References

Fixes #1181

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [X] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
