### PR TITLE
fix: missing jsdocs for `templates.recaptcha_enterprise`

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -152,6 +152,7 @@ function handleRecaptchaProvider(element, options, challenge) {
  * @param {Object} [options.templates] An object containaing templates for each captcha provider
  * @param {Function} [options.templates.auth0] template function receiving the challenge and returning an string
  * @param {Function} [options.templates.recaptcha_v2] template function receiving the challenge and returning an string
+ * @param {Function} [options.templates.recaptcha_enterprise] template function receiving the challenge and returning an string
  * @param {String} [options.lang=en] the ISO code of the language for recaptcha*
  * @param {Function} [callback] an optional callback function
  */

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1026,6 +1026,7 @@ WebAuth.prototype.passwordlessVerify = function(options, cb) {
  * @param {Object} [options.templates] An object containaing templates for each captcha provider
  * @param {Function} [options.templates.auth0] template function receiving the challenge and returning an string
  * @param {Function} [options.templates.recaptcha_v2] template function receiving the challenge and returning an string
+ * @param {Function} [options.templates.recaptcha_enterprise] template function receiving the challenge and returning an string
  * @param {String} [options.lang=en] the ISO code of the language for recaptcha
  * @param {Function} [callback] An optional completion callback
  */


### PR DESCRIPTION
### Changes

Receive one report of missing docs for the `recaptcha_enterprise` option in our public docs: ex. https://auth0.github.io/auth0.js/WebAuth.html#renderCaptcha

We would need to re-render the docs after this PR is merged please.

### References

https://auth0team.atlassian.net/browse/ESD-14287

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
