### PR TITLE
Ensure docs for Redirect are published

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -167,6 +167,8 @@ function WebAuth(options) {
   this.transactionManager = new TransactionManager(this.baseOptions);
 
   this.client = new Authentication(this.baseOptions);
+
+  /** @member {Redirect} */
   this.redirect = new Redirect(this, this.baseOptions);
 
   /** @member {Popup} */
@@ -176,6 +178,7 @@ function WebAuth(options) {
     this,
     this.baseOptions
   );
+
   this.webMessageHandler = new WebMessageHandler(this);
   this._universalLogin = new HostedPages(this, this.baseOptions);
   this.ssodataStorage = new SSODataStorage(this.baseOptions);

--- a/src/web-auth/redirect.js
+++ b/src/web-auth/redirect.js
@@ -1,6 +1,11 @@
 import CrossOriginAuthentication from './cross-origin-authentication';
 import Warn from '../helper/warn';
 
+/**
+ * @class
+ * @classdesc This class cannot be instantiated directly. Instead, use WebAuth.redirect
+ * @hideconstructor
+ */
 function Redirect(auth0, options) {
   this.webAuth = auth0;
   this.baseOptions = options;
@@ -27,7 +32,8 @@ function Redirect(auth0, options) {
  * @param {String} options.password Password
  * @param {String} [options.connection] Connection used to authenticate the user, it can be a realm name or a database connection name
  * @param {crossOriginLoginCallback} cb Callback function called only when an authentication error, like invalid username or password, occurs. For other types of errors, there will be a redirect to the `redirectUri`.
- * @ignore
+ * @memberof Redirect.prototype
+ * @memberof Redirect.prototype
  */
 Redirect.prototype.loginWithCredentials = function(options, cb) {
   options.realm = options.realm || options.connection;
@@ -44,16 +50,19 @@ Redirect.prototype.loginWithCredentials = function(options, cb) {
  * @param {String} options.password user password
  * @param {String} options.connection name of the connection where the user will be created
  * @param {crossOriginLoginCallback} cb
- * @ignore
+ * @memberof Redirect.prototype
  */
 Redirect.prototype.signupAndLogin = function(options, cb) {
   var _this = this;
+
   return this.webAuth.client.dbConnection.signup(options, function(err) {
     if (err) {
       return cb(err);
     }
+
     options.realm = options.realm || options.connection;
     delete options.connection;
+
     return _this.webAuth.login(options, cb);
   });
 };


### PR DESCRIPTION
### Changes

Currently the [published docs]() are missing documentation for the `Redirect`, accessed through `WebAuth`. This PR corrects that.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
