### PR TITLE
Update index.js

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -214,10 +214,8 @@ WebAuth.prototype.parseHash = function(options, cb) {
     options = options || {};
   }
 
-  var _window = windowHelper.getWindow();
-
   var hashStr =
-    options.hash === undefined ? _window.location.hash : options.hash;
+    options.hash === undefined ? windowHelper.getWindow().location.hash : options.hash;
   hashStr = hashStr.replace(/^#?\/?/, '');
 
   parsedQs = qs.parse(hashStr);


### PR DESCRIPTION
check window object only if it is options.hash is not set.

### Changes

If I try to access auth instance method `parseHash` within node env - it will throw error. So by doing that - window object will be requested as a fallback if no option is provided.

Thank you