### PR TITLE
Set sameSite to 'none' for cookies when using HTTPS

### DIFF
--- a/src/helper/storage/cookie.js
+++ b/src/helper/storage/cookie.js
@@ -3,15 +3,15 @@ import objectHelper from '../object';
 import windowHandler from '../window';
 function CookieStorage() {}
 
-CookieStorage.prototype.getItem = function(key) {
+CookieStorage.prototype.getItem = function (key) {
   return Cookie.get(key);
 };
 
-CookieStorage.prototype.removeItem = function(key) {
+CookieStorage.prototype.removeItem = function (key) {
   Cookie.remove(key);
 };
 
-CookieStorage.prototype.setItem = function(key, value, options) {
+CookieStorage.prototype.setItem = function (key, value, options) {
   var params = objectHelper.extend(
     {
       expires: 1 // 1 day
@@ -21,6 +21,7 @@ CookieStorage.prototype.setItem = function(key, value, options) {
 
   if (windowHandler.getWindow().location.protocol === 'https:') {
     params.secure = true;
+    params.sameSite = 'none';
   }
 
   Cookie.set(key, value, params);

--- a/test/helper/storage.cookie.test.js
+++ b/test/helper/storage.cookie.test.js
@@ -9,40 +9,40 @@ var cookieStorage = new CookieStorage();
 const KEY = 'foo';
 const VALUE = 'bar';
 
-describe('storage.cookies', function() {
-  beforeEach(function() {
-    sinon.stub(CookieLibrary, 'get').callsFake(function(key) {
+describe('storage.cookies', function () {
+  beforeEach(function () {
+    sinon.stub(CookieLibrary, 'get').callsFake(function (key) {
       expect(key).to.be(KEY);
       return VALUE;
     });
-    sinon.stub(CookieLibrary, 'set').callsFake(function(key, value) {
+    sinon.stub(CookieLibrary, 'set').callsFake(function (key, value) {
       expect(key).to.be(KEY);
       expect(value).to.be(VALUE);
     });
-    sinon.stub(CookieLibrary, 'remove').callsFake(function(key) {
+    sinon.stub(CookieLibrary, 'remove').callsFake(function (key) {
       expect(key).to.be(KEY);
     });
   });
-  afterEach(function() {
+  afterEach(function () {
     CookieLibrary.get.restore();
     CookieLibrary.set.restore();
     CookieLibrary.remove.restore();
   });
-  describe('getItem', function() {
-    it('calls Cookie.get', function() {
+  describe('getItem', function () {
+    it('calls Cookie.get', function () {
       const value = cookieStorage.getItem(KEY);
       expect(value).to.be(VALUE);
     });
   });
-  describe('removeItem', function() {
-    it('calls Cookie.remove', function(done) {
+  describe('removeItem', function () {
+    it('calls Cookie.remove', function (done) {
       cookieStorage.removeItem(KEY);
       done();
     });
   });
-  describe('setItem', function() {
-    beforeEach(function() {
-      sinon.stub(windowHandler, 'getWindow').callsFake(function() {
+  describe('setItem', function () {
+    beforeEach(function () {
+      sinon.stub(windowHandler, 'getWindow').callsFake(function () {
         return {
           location: {
             protocol: 'http:'
@@ -51,11 +51,11 @@ describe('storage.cookies', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       windowHandler.getWindow.restore();
     });
 
-    it('calls Cookie.set with default values', function() {
+    it('calls Cookie.set with default values', function () {
       cookieStorage.setItem(KEY, VALUE);
 
       expect(CookieLibrary.set.firstCall.args).to.be.eql([
@@ -65,7 +65,7 @@ describe('storage.cookies', function() {
       ]);
     });
 
-    it('calls Cookie.set with custom values', function() {
+    it('calls Cookie.set with custom values', function () {
       cookieStorage.setItem(KEY, VALUE, { expires: 2, test: true });
 
       expect(CookieLibrary.set.firstCall.args).to.be.eql([
@@ -75,9 +75,9 @@ describe('storage.cookies', function() {
       ]);
     });
 
-    it('sets the secure flag on cookies when using the https protocol', function() {
+    it('sets the secure flag on cookies when using the https protocol', function () {
       windowHandler.getWindow.restore();
-      sinon.stub(windowHandler, 'getWindow').callsFake(function() {
+      sinon.stub(windowHandler, 'getWindow').callsFake(function () {
         return {
           location: {
             protocol: 'https:'
@@ -90,7 +90,7 @@ describe('storage.cookies', function() {
       expect(CookieLibrary.set.firstCall.args).to.be.eql([
         'foo',
         'bar',
-        { expires: 2, test: true, secure: true }
+        { expires: 2, test: true, secure: true, sameSite: 'none' }
       ]);
     });
   });


### PR DESCRIPTION
### Changes

Sets `sameSite` to `none` when using HTTPS to resolve browser warnings.

### References

- Internal service desk ticket `ESD-17541`
- #1220

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
