### PR TITLE
support timeout option in Popup.loginWithCredentials

### DIFF
--- a/src/web-auth/popup.js
+++ b/src/web-auth/popup.js
@@ -252,12 +252,19 @@ Popup.prototype.authorize = function(options, cb) {
  * @param {credentialsCallback} cb
  * @memberof Popup.prototype
  */
-Popup.prototype.loginWithCredentials = function(options, cb) {
+Popup.prototype.loginWithCredentials = function (options, cb) {
   options.realm = options.realm || options.connection;
   options.popup = true;
   options = objectHelper
-    .merge(this.baseOptions, ['redirectUri', 'responseType', 'state', 'nonce'])
+    .merge(this.baseOptions, [
+      'redirectUri',
+      'responseType',
+      'state',
+      'nonce',
+      'timeout'
+    ])
     .with(objectHelper.blacklist(options, ['popupHandler', 'connection']));
+
   options = this.transactionManager.process(options);
   this.crossOriginAuthentication.login(options, cb);
 };

--- a/test/web-auth/popup.test.js
+++ b/test/web-auth/popup.test.js
@@ -13,18 +13,18 @@ import WebAuth from '../../src/web-auth';
 import CrossOriginAuthentication from '../../src/web-auth/cross-origin-authentication';
 import TransactionManager from '../../src/web-auth/transaction-manager';
 
-describe('auth0.WebAuth.popup', function() {
-  beforeEach(function() {
+describe('auth0.WebAuth.popup', function () {
+  beforeEach(function () {
     sinon
       .stub(TransactionManager.prototype, 'generateTransaction')
-      .callsFake(function(appState, state, nonce) {
+      .callsFake(function (appState, state, nonce) {
         return { state: state || 'randomState', nonce: nonce || 'randomNonce' };
       });
   });
-  afterEach(function() {
+  afterEach(function () {
     TransactionManager.prototype.generateTransaction.restore();
   });
-  before(function() {
+  before(function () {
     this.auth0 = new WebAuth({
       domain: 'me.auth0.com',
       clientID: '...',
@@ -35,13 +35,13 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  describe('getPopupHandler', function() {
-    it('should return a new instance', function() {
+  describe('getPopupHandler', function () {
+    it('should return a new instance', function () {
       var handler1 = this.auth0.popup.getPopupHandler({});
       var handler2 = this.auth0.popup.getPopupHandler({});
       expect(handler1).to.not.be(handler2);
     });
-    it('should return not a new instance', function() {
+    it('should return not a new instance', function () {
       var handler1 = this.auth0.popup.getPopupHandler({});
       var handler2 = this.auth0.popup.getPopupHandler({
         popupHandler: handler1
@@ -50,26 +50,26 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  describe('getPopupHandler should preload when requested', function() {
-    afterEach(function() {
+  describe('getPopupHandler should preload when requested', function () {
+    afterEach(function () {
       PopupHandler.prototype.preload.restore();
     });
 
-    it('should call preload', function() {
+    it('should call preload', function () {
       var preloadStub = sinon.stub(PopupHandler.prototype, 'preload');
       this.auth0.popup.getPopupHandler({}, true);
       expect(preloadStub.called).to.be(true);
     });
 
-    it('should not call preload', function() {
+    it('should not call preload', function () {
       var preloadStub = sinon.stub(PopupHandler.prototype, 'preload');
       this.auth0.popup.getPopupHandler({}, false);
       expect(preloadStub.called).to.be(false);
     });
   });
 
-  describe('preload should open the popup', function() {
-    before(function() {
+  describe('preload should open the popup', function () {
+    before(function () {
       global.window = {};
       global.window.screenX = 500;
       global.window.screenY = 500;
@@ -85,19 +85,19 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    after(function() {
+    after(function () {
       delete global.window;
     });
 
-    it('should open the window', function() {
-      global.window.open = function(url, name, windowFeatures) {
+    it('should open the window', function () {
+      global.window.open = function (url, name, windowFeatures) {
         expect(url).to.eql('about:blank');
         expect(name).to.eql('auth0_signup_popup');
         expect(windowFeatures).to.eql(
           'width=500,height=600,left=1250,top=1200'
         );
 
-        return { close: function() {} };
+        return { close: function () {} };
       };
 
       var handler = new PopupHandler();
@@ -106,8 +106,8 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  context('authorize', function() {
-    before(function() {
+  context('authorize', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -117,12 +117,12 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       PopupHandler.prototype.load.restore();
     });
 
-    it('should default scope to openid', function(done) {
-      sinon.stub(PopupHandler.prototype, 'load').callsFake(function(url) {
+    it('should default scope to openid', function (done) {
+      sinon.stub(PopupHandler.prototype, 'load').callsFake(function (url) {
         expect(url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&connection=the_connection&state=123&nonce=456&scope=openid'
         );
@@ -130,10 +130,10 @@ describe('auth0.WebAuth.popup', function() {
         TransactionManager.prototype.process.restore();
         done();
       });
-      sinon.stub(Storage.prototype, 'setItem').callsFake(function() {});
+      sinon.stub(Storage.prototype, 'setItem').callsFake(function () {});
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(options) {
+        .callsFake(function (options) {
           return options;
         });
 
@@ -145,7 +145,7 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    it('should pass organization and invitation params to buildAuthorizeUrl from the constructor', function(done) {
+    it('should pass organization and invitation params to buildAuthorizeUrl from the constructor', function (done) {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -157,7 +157,7 @@ describe('auth0.WebAuth.popup', function() {
         invitation: 'inv_123'
       });
 
-      sinon.stub(PopupHandler.prototype, 'load').callsFake(function(url) {
+      sinon.stub(PopupHandler.prototype, 'load').callsFake(function (url) {
         expect(url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&organization=org_123&invitation=inv_123&connection=the_connection&state=123&nonce=456&scope=openid'
         );
@@ -168,11 +168,11 @@ describe('auth0.WebAuth.popup', function() {
         done();
       });
 
-      sinon.stub(Storage.prototype, 'setItem').callsFake(function() {});
+      sinon.stub(Storage.prototype, 'setItem').callsFake(function () {});
 
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(options) {
+        .callsFake(function (options) {
           return options;
         });
 
@@ -184,8 +184,8 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    it('should pass organization and invitation params to buildAuthorizeUrl from authorize', function(done) {
-      sinon.stub(PopupHandler.prototype, 'load').callsFake(function(url) {
+    it('should pass organization and invitation params to buildAuthorizeUrl from authorize', function (done) {
+      sinon.stub(PopupHandler.prototype, 'load').callsFake(function (url) {
         expect(url).to.be(
           'https://me.auth0.com/authorize?client_id=...&response_type=id_token&redirect_uri=http%3A%2F%2Fpage.com%2Fcallback&organization=org_123&invitation=inv_123&connection=the_connection&state=123&nonce=456&scope=openid'
         );
@@ -196,11 +196,11 @@ describe('auth0.WebAuth.popup', function() {
         done();
       });
 
-      sinon.stub(Storage.prototype, 'setItem').callsFake(function() {});
+      sinon.stub(Storage.prototype, 'setItem').callsFake(function () {});
 
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(options) {
+        .callsFake(function (options) {
           return options;
         });
 
@@ -214,10 +214,10 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    it('should open the popup a with the proper parameters', function(done) {
+    it('should open the popup a with the proper parameters', function (done) {
       sinon
         .stub(PopupHandler.prototype, 'load')
-        .callsFake(function(url, relayUrl, options, cb) {
+        .callsFake(function (url, relayUrl, options, cb) {
           expect(relayUrl).to.be('https://me.auth0.com/relay.html');
           expect(options.popupOptions.height).to.be(300);
           expect(options.popupOptions.width).to.be(250);
@@ -240,16 +240,16 @@ describe('auth0.WebAuth.popup', function() {
             extra: 'disallowed'
           }
         },
-        function(err, data) {
+        function (err, data) {
           done();
         }
       );
     });
 
-    it('should open the authorize page in a popup', function(done) {
+    it('should open the authorize page in a popup', function (done) {
       sinon
         .stub(PopupHandler.prototype, 'load')
-        .callsFake(function(url, relayUrl, options, cb) {
+        .callsFake(function (url, relayUrl, options, cb) {
           var components = URL.parse(url, true);
           expect(components.protocol).to.be('https:');
           expect(components.host).to.be('me.auth0.com');
@@ -275,7 +275,7 @@ describe('auth0.WebAuth.popup', function() {
           state: '456',
           owp: true
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             emailVerified: false,
@@ -288,8 +288,8 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  context('login', function() {
-    before(function() {
+  context('login', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -299,7 +299,7 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       if (CrossOriginAuthentication.prototype.login.restore) {
         CrossOriginAuthentication.prototype.login.restore();
       }
@@ -310,7 +310,7 @@ describe('auth0.WebAuth.popup', function() {
         TransactionManager.prototype.process.restore();
       }
     });
-    it('should call CrossOriginAuthentication.login', function(done) {
+    it('should call CrossOriginAuthentication.login', function (done) {
       var inputOptions = { foo: 'bar', connection: 'realm' };
       var expectedOptions = {
         foo: 'bar',
@@ -321,25 +321,66 @@ describe('auth0.WebAuth.popup', function() {
       };
       sinon
         .stub(CrossOriginAuthentication.prototype, 'login')
-        .callsFake(function(options, cb) {
+        .callsFake(function (options, cb) {
           expect(options).to.be.eql(expectedOptions);
           expect(cb()).to.be('cb');
           done();
         });
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(options) {
+        .callsFake(function (options) {
           expect(options).to.be.eql(expectedOptions);
           return options;
         });
-      this.auth0.popup.loginWithCredentials(inputOptions, function() {
+      this.auth0.popup.loginWithCredentials(inputOptions, function () {
+        return 'cb';
+      });
+    });
+
+    it('should pass through the timeout base option', function (done) {
+      var inputOptions = { foo: 'bar', connection: 'realm' };
+
+      var expectedOptions = {
+        foo: 'bar',
+        realm: 'realm',
+        responseType: 'id_token',
+        redirectUri: 'http://page.com/callback',
+        popup: true,
+        timeout: 1234
+      };
+
+      sinon
+        .stub(CrossOriginAuthentication.prototype, 'login')
+        .callsFake(function (options, cb) {
+          expect(options).to.be.eql(expectedOptions);
+          expect(cb()).to.be('cb');
+          done();
+        });
+
+      sinon
+        .stub(TransactionManager.prototype, 'process')
+        .callsFake(function (options) {
+          expect(options).to.be.eql(expectedOptions);
+          return options;
+        });
+
+      var auth0 = new WebAuth({
+        domain: 'me.auth0.com',
+        clientID: '...',
+        redirectUri: 'http://page.com/callback',
+        responseType: 'id_token',
+        _sendTelemetry: false,
+        timeout: 1234
+      });
+
+      auth0.popup.loginWithCredentials(inputOptions, function () {
         return 'cb';
       });
     });
   });
 
-  context('passwordlessVerify', function() {
-    before(function() {
+  context('passwordlessVerify', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -349,12 +390,12 @@ describe('auth0.WebAuth.popup', function() {
       });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       request.post.restore();
     });
 
-    it('(phone) should do the redirections in the popup', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('(phone) should do the redirections in the popup', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect([
           'https://me.auth0.com/passwordless/verify',
           'https://me.auth0.com/oauth/ro'
@@ -370,7 +411,7 @@ describe('auth0.WebAuth.popup', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {}
               });
@@ -390,7 +431,7 @@ describe('auth0.WebAuth.popup', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   idToken: 'id_token.id_token.id_token',
@@ -409,7 +450,7 @@ describe('auth0.WebAuth.popup', function() {
           phoneNumber: '+5491178786555',
           verificationCode: '123'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             idToken: 'id_token.id_token.id_token',
@@ -421,8 +462,8 @@ describe('auth0.WebAuth.popup', function() {
       );
     });
 
-    it('(email) should do the redirections in the popup', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('(email) should do the redirections in the popup', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect([
           'https://me.auth0.com/passwordless/verify',
           'https://me.auth0.com/oauth/ro'
@@ -438,7 +479,7 @@ describe('auth0.WebAuth.popup', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {}
               });
@@ -458,7 +499,7 @@ describe('auth0.WebAuth.popup', function() {
             headers: {
               'Content-Type': 'application/json'
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   id_token: 'id_token.id_token.id_token',
@@ -477,7 +518,7 @@ describe('auth0.WebAuth.popup', function() {
           email: 'test@example.com',
           verificationCode: '123'
         },
-        function(err, data) {
+        function (err, data) {
           expect(err).to.be(null);
           expect(data).to.eql({
             idToken: 'id_token.id_token.id_token',
@@ -489,7 +530,7 @@ describe('auth0.WebAuth.popup', function() {
       );
     });
 
-    it('should propagate the error', function(done) {
+    it('should propagate the error', function (done) {
       var assert_err = {};
       assert_err.response = {};
       assert_err.response.body = {
@@ -497,7 +538,7 @@ describe('auth0.WebAuth.popup', function() {
         description: 'The error description.'
       };
 
-      sinon.stub(request, 'post').callsFake(function(url) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.eql('https://me.auth0.com/passwordless/verify');
         return new RequestMock({
           body: {
@@ -508,7 +549,7 @@ describe('auth0.WebAuth.popup', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(assert_err);
           }
         });
@@ -520,7 +561,7 @@ describe('auth0.WebAuth.popup', function() {
           phoneNumber: '+5491178786555',
           verificationCode: '123'
         },
-        function(err, data) {
+        function (err, data) {
           expect(data).to.be(undefined);
           expect(err).to.eql({
             original: assert_err,
@@ -533,8 +574,8 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  context('signup and login', function() {
-    before(function() {
+  context('signup and login', function () {
+    before(function () {
       this.auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -543,15 +584,15 @@ describe('auth0.WebAuth.popup', function() {
         _sendTelemetry: false
       });
 
-      sinon.stub(windowHandler, 'getWindow').callsFake(function() {
+      sinon.stub(windowHandler, 'getWindow').callsFake(function () {
         return {
           screenX: 500,
           screenY: 500,
           outerWidth: 2000,
           outerHeight: 500,
-          open: function() {
+          open: function () {
             return {
-              close: function() {}
+              close: function () {}
             };
           }
         };
@@ -559,7 +600,7 @@ describe('auth0.WebAuth.popup', function() {
 
       sinon
         .stub(PopupHandler.prototype, 'load')
-        .callsFake(function(url, relayUrl, options, cb) {
+        .callsFake(function (url, relayUrl, options, cb) {
           expect(url).to.be('https://me.auth0.com/sso_dbconnection_popup/...');
           expect(relayUrl).to.be('https://me.auth0.com/relay.html');
           expect(options).to.eql({
@@ -579,7 +620,7 @@ describe('auth0.WebAuth.popup', function() {
         });
     });
 
-    afterEach(function() {
+    afterEach(function () {
       request.post.restore();
       if (CrossOriginAuthentication.prototype.login.restore) {
         CrossOriginAuthentication.prototype.login.restore();
@@ -592,13 +633,13 @@ describe('auth0.WebAuth.popup', function() {
       }
     });
 
-    after(function() {
+    after(function () {
       windowHandler.getWindow.restore();
       PopupHandler.prototype.load.restore();
     });
 
-    it('should call db-connection signup with all the options', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should call db-connection signup with all the options', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.eql('https://me.auth0.com/dbconnections/signup');
 
         return new RequestMock({
@@ -611,7 +652,7 @@ describe('auth0.WebAuth.popup', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb(null, {
               body: {
                 _id: '...',
@@ -634,14 +675,14 @@ describe('auth0.WebAuth.popup', function() {
       };
       sinon
         .stub(TransactionManager.prototype, 'process')
-        .callsFake(function(options) {
+        .callsFake(function (options) {
           delete options.popupHandler;
           expect(options).to.be.eql(expectedOptions);
           return options;
         });
       sinon
         .stub(CrossOriginAuthentication.prototype, 'login')
-        .callsFake(function(options, cb) {
+        .callsFake(function (options, cb) {
           delete options.popupHandler;
           expect(options).to.be.eql(expectedOptions);
           cb();
@@ -654,14 +695,14 @@ describe('auth0.WebAuth.popup', function() {
           password: '123456',
           scope: 'openid'
         },
-        function(err, data) {
+        function (err, data) {
           done();
         }
       );
     });
 
-    it('should propagate signup errors', function(done) {
-      sinon.stub(request, 'post').callsFake(function(url) {
+    it('should propagate signup errors', function (done) {
+      sinon.stub(request, 'post').callsFake(function (url) {
         expect(url).to.be('https://me.auth0.com/dbconnections/signup');
 
         return new RequestMock({
@@ -674,7 +715,7 @@ describe('auth0.WebAuth.popup', function() {
           headers: {
             'Content-Type': 'application/json'
           },
-          cb: function(cb) {
+          cb: function (cb) {
             cb({
               response: {
                 statusCode: 400,
@@ -695,7 +736,7 @@ describe('auth0.WebAuth.popup', function() {
           password: '123456',
           scope: 'openid'
         },
-        function(err, data) {
+        function (err, data) {
           expect(data).to.be(undefined);
           expect(err).to.eql({
             original: {
@@ -717,15 +758,15 @@ describe('auth0.WebAuth.popup', function() {
     });
   });
 
-  context('callback', function() {
-    beforeEach(function() {
-      sinon.stub(windowHandler, 'getWindow').callsFake(function() {
+  context('callback', function () {
+    beforeEach(function () {
+      sinon.stub(windowHandler, 'getWindow').callsFake(function () {
         return {
           opener: {}
         };
       });
     });
-    afterEach(function() {
+    afterEach(function () {
       if (WinChan.onOpen.restore) {
         WinChan.onOpen.restore();
       }
@@ -737,74 +778,82 @@ describe('auth0.WebAuth.popup', function() {
       }
       windowHandler.getWindow.restore();
     });
-    it('sends parseHash result to the callback when there is no error', function(done) {
-      sinon.stub(this.auth0, 'parseHash').callsFake(function(options, cb) {
+    it('sends parseHash result to the callback when there is no error', function (done) {
+      sinon.stub(this.auth0, 'parseHash').callsFake(function (options, cb) {
         cb(null, { accessToken: 'accessToken' });
       });
-      sinon.stub(WinChan, 'onOpen').callsFake(function(onOpenCallback) {
-        onOpenCallback('https://baseoptions.popupOrigin.com', null, function(
-          result
-        ) {
-          expect(result).to.be.eql({ accessToken: 'accessToken' });
-          done();
-        });
+      sinon.stub(WinChan, 'onOpen').callsFake(function (onOpenCallback) {
+        onOpenCallback(
+          'https://baseoptions.popupOrigin.com',
+          null,
+          function (result) {
+            expect(result).to.be.eql({ accessToken: 'accessToken' });
+            done();
+          }
+        );
       });
 
       this.auth0.popup.callback();
     });
-    it('sends parseHash result to the callback when there is an error', function(done) {
-      sinon.stub(this.auth0, 'parseHash').callsFake(function(options, cb) {
+    it('sends parseHash result to the callback when there is an error', function (done) {
+      sinon.stub(this.auth0, 'parseHash').callsFake(function (options, cb) {
         cb({ error: 'any_error', error_description: 'a big error message' });
       });
-      sinon.stub(WinChan, 'onOpen').callsFake(function(onOpenCallback) {
-        onOpenCallback('https://baseoptions.popupOrigin.com', null, function(
-          result
-        ) {
-          expect(result).to.be.eql({
-            error: 'any_error',
-            error_description: 'a big error message'
-          });
-          done();
-        });
+      sinon.stub(WinChan, 'onOpen').callsFake(function (onOpenCallback) {
+        onOpenCallback(
+          'https://baseoptions.popupOrigin.com',
+          null,
+          function (result) {
+            expect(result).to.be.eql({
+              error: 'any_error',
+              error_description: 'a big error message'
+            });
+            done();
+          }
+        );
       });
 
       this.auth0.popup.callback();
     });
-    it('validates origin with baseOptions.popupOrigin', function(done) {
-      sinon.stub(WinChan, 'onOpen').callsFake(function(onOpenCallback) {
-        onOpenCallback('https://notBaseOptions.popupOrigin.com', null, function(
-          result
-        ) {
-          expect(result).to.be.eql({
-            error: 'origin_mismatch',
-            error_description:
-              "The popup's origin (https://notBaseOptions.popupOrigin.com) should match the `popupOrigin` parameter (https://baseoptions.popupOrigin.com)."
-          });
-          done();
-        });
+    it('validates origin with baseOptions.popupOrigin', function (done) {
+      sinon.stub(WinChan, 'onOpen').callsFake(function (onOpenCallback) {
+        onOpenCallback(
+          'https://notBaseOptions.popupOrigin.com',
+          null,
+          function (result) {
+            expect(result).to.be.eql({
+              error: 'origin_mismatch',
+              error_description:
+                "The popup's origin (https://notBaseOptions.popupOrigin.com) should match the `popupOrigin` parameter (https://baseoptions.popupOrigin.com)."
+            });
+            done();
+          }
+        );
       });
 
       this.auth0.popup.callback();
     });
-    it('validates origin with options.popupOrigin', function(done) {
-      sinon.stub(WinChan, 'onOpen').callsFake(function(onOpenCallback) {
-        onOpenCallback('https://notOptions.popupOrigin.com', null, function(
-          result
-        ) {
-          expect(result).to.be.eql({
-            error: 'origin_mismatch',
-            error_description:
-              "The popup's origin (https://notOptions.popupOrigin.com) should match the `popupOrigin` parameter (https://options.popupOrigin.com)."
-          });
-          done();
-        });
+    it('validates origin with options.popupOrigin', function (done) {
+      sinon.stub(WinChan, 'onOpen').callsFake(function (onOpenCallback) {
+        onOpenCallback(
+          'https://notOptions.popupOrigin.com',
+          null,
+          function (result) {
+            expect(result).to.be.eql({
+              error: 'origin_mismatch',
+              error_description:
+                "The popup's origin (https://notOptions.popupOrigin.com) should match the `popupOrigin` parameter (https://options.popupOrigin.com)."
+            });
+            done();
+          }
+        );
       });
 
       this.auth0.popup.callback({
         popupOrigin: 'https://options.popupOrigin.com'
       });
     });
-    it('validates origin with windowHelper.getOrigin()', function(done) {
+    it('validates origin with windowHelper.getOrigin()', function (done) {
       var auth0 = new WebAuth({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -812,40 +861,42 @@ describe('auth0.WebAuth.popup', function() {
         responseType: 'id_token',
         _sendTelemetry: false
       });
-      sinon.stub(windowHandler, 'getOrigin').callsFake(function() {
+      sinon.stub(windowHandler, 'getOrigin').callsFake(function () {
         return 'https://window.popupOrigin.com';
       });
-      sinon.stub(WinChan, 'onOpen').callsFake(function(onOpenCallback) {
-        onOpenCallback('https://notWindow.popupOrigin.com', null, function(
-          result
-        ) {
-          expect(result).to.be.eql({
-            error: 'origin_mismatch',
-            error_description:
-              "The popup's origin (https://notWindow.popupOrigin.com) should match the `popupOrigin` parameter (https://window.popupOrigin.com)."
-          });
-          done();
-        });
+      sinon.stub(WinChan, 'onOpen').callsFake(function (onOpenCallback) {
+        onOpenCallback(
+          'https://notWindow.popupOrigin.com',
+          null,
+          function (result) {
+            expect(result).to.be.eql({
+              error: 'origin_mismatch',
+              error_description:
+                "The popup's origin (https://notWindow.popupOrigin.com) should match the `popupOrigin` parameter (https://window.popupOrigin.com)."
+            });
+            done();
+          }
+        );
       });
 
       auth0.popup.callback();
     });
-    it('handles window.opener being undefined', function(done) {
+    it('handles window.opener being undefined', function (done) {
       windowHandler.getWindow.restore();
       var theWindow = {
         opener: undefined,
         parent: {
-          postMessage: function(msg, origin) {
+          postMessage: function (msg, origin) {
             expect(msg).to.be.eql({ from: 'winchan' });
             expect(origin).to.be('https://window.popupOrigin.com');
             done();
           }
         }
       };
-      sinon.stub(windowHandler, 'getWindow').callsFake(function() {
+      sinon.stub(windowHandler, 'getWindow').callsFake(function () {
         return theWindow;
       });
-      sinon.stub(windowHandler, 'getOrigin').callsFake(function() {
+      sinon.stub(windowHandler, 'getOrigin').callsFake(function () {
         return 'https://window.popupOrigin.com';
       });
       var auth0 = new WebAuth({


### PR DESCRIPTION
### Changes

This PR allows `timeout` to be passed through when calling `Popup.loginWithCredentials`, which ultimately ends up configuring the iframe generated by `WebMessageHandler` just like in other login methods.

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
