### PR TITLE
chore: scope npm package to paymentsense

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.paymentsense.tech/repository/npm/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auth0-js",
+  "name": "@paymentsense/auth0-js",
   "version": "9.20.0",
   "description": "Auth0 headless browser sdk",
   "author": "Auth0",
@@ -49,7 +49,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/auth0/auth0.js"
+    "url": "git://github.com/dojo-engineering-dev/auth0.js"
   },
   "dependencies": {
     "base64-js": "^1.5.1",


### PR DESCRIPTION
### Changes

- Scoped this package to @paymentsense org
- Updated repo url for package to point to **dojo-engineering-dev**
- Add Paymentsense registry URL to `.npmrc`
