### PR TITLE
Update API docs to not mention recaptcha

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1145,7 +1145,7 @@ WebAuth.prototype.passwordlessVerify = function (options, cb) {
  * @param {Function} [options.templates.hcaptcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.friendly_captcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
- * @param {String} [options.lang=en] the ISO code of the language for recaptcha
+ * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {Function} [callback] An optional completion callback
  * @memberof WebAuth.prototype
  */
@@ -1168,7 +1168,7 @@ WebAuth.prototype.renderCaptcha = function (element, options, callback) {
  * @param {Function} [options.templates.hcaptcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.friendly_captcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
- * @param {String} [options.lang=en] the ISO code of the language for recaptcha
+ * @param {String} [options.lang=en] the ISO code of the language for captcha provider
  * @param {Function} [callback] An optional completion callback
  * @memberof WebAuth.prototype
  */

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1168,7 +1168,7 @@ WebAuth.prototype.renderCaptcha = function (element, options, callback) {
  * @param {Function} [options.templates.hcaptcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.friendly_captcha] template function receiving the challenge and returning a string 
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
- * @param {String} [options.lang=en] the ISO code of the language for captcha provider
+ * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {Function} [callback] An optional completion callback
  * @memberof WebAuth.prototype
  */


### PR DESCRIPTION
### Changes

As we support multiple captcha providers we shouldnt specifically mention the language property is for recaptcha, as it's used for all of them.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
