### PR TITLE
Bump idtoken-verifier from 2.2.2 to 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",
-        "idtoken-verifier": "^2.2.2",
+        "idtoken-verifier": "^2.2.4",
         "js-cookie": "^2.2.0",
         "minimist": "^1.2.5",
         "qs": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "base64-js": "^1.5.1",
-    "idtoken-verifier": "^2.2.2",
+    "idtoken-verifier": "^2.2.4",
     "js-cookie": "^2.2.0",
     "minimist": "^1.2.5",
     "qs": "^6.10.1",


### PR DESCRIPTION
### Changes

Bumps [idtoken-verifier](https://github.com/auth0/idtoken-verifier) from 2.2.2 to 2.2.4.

### References

### Testing

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
