### PR TITLE
[IAMRISK-2916] Added support for Auth0 v2 captcha provider

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1151,6 +1151,7 @@ WebAuth.prototype.passwordlessVerify = function (options, cb) {
  * @param {Function} [options.templates.hcaptcha] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.friendly_captcha] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.arkose] template function receiving the challenge and returning a string
+ * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded
@@ -1175,6 +1176,7 @@ WebAuth.prototype.renderCaptcha = function (element, options, callback) {
  * @param {Function} [options.templates.hcaptcha] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.friendly_captcha] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.arkose] template function receiving the challenge and returning a string
+ * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -216,18 +216,14 @@ describe('captcha rendering', function () {
       }
     };
     const getHostname = () => {
-      switch (provider) {
-        case RECAPTCHA_V2_PROVIDER:
-          return 'recaptcha.net';
-        case RECAPTCHA_ENTERPRISE_PROVIDER:
-          return 'recaptcha.net';
-        case HCAPTCHA_PROVIDER:
-          return 'hcaptcha.com';
-        case FRIENDLY_CAPTCHA_PROVIDER:
-          return 'jsdelivr.net';
-        case AUTH0_V2_CAPTCHA_PROVIDER:
-          return 'cloudflare.com';
+      const hosts = {
+        [RECAPTCHA_V2_PROVIDER]: 'recaptcha.net',
+        [RECAPTCHA_ENTERPRISE_PROVIDER]: 'recaptcha.net',
+        [HCAPTCHA_PROVIDER]: 'hcaptcha.com',
+        [FRIENDLY_CAPTCHA_PROVIDER]: 'jsdelivr.net',
+        [AUTH0_V2_CAPTCHA_PROVIDER]: 'cloudflare.com'
       }
+      return hosts[provider];
     };
     const getSubdomain = () => {
       switch (provider) {
@@ -790,18 +786,14 @@ describe('passwordless captcha rendering', function () {
       }
     };
     const getHostname = () => {
-      switch (provider) {
-        case RECAPTCHA_V2_PROVIDER:
-          return 'recaptcha.net';
-        case RECAPTCHA_ENTERPRISE_PROVIDER:
-          return 'recaptcha.net';
-        case HCAPTCHA_PROVIDER:
-          return 'hcaptcha.com';
-        case FRIENDLY_CAPTCHA_PROVIDER:
-          return 'jsdelivr.net';
-        case AUTH0_V2_CAPTCHA_PROVIDER:
-          return 'cloudflare.com';
+      const hosts = {
+        [RECAPTCHA_V2_PROVIDER]: 'recaptcha.net',
+        [RECAPTCHA_ENTERPRISE_PROVIDER]: 'recaptcha.net',
+        [HCAPTCHA_PROVIDER]: 'hcaptcha.com',
+        [FRIENDLY_CAPTCHA_PROVIDER]: 'jsdelivr.net',
+        [AUTH0_V2_CAPTCHA_PROVIDER]: 'cloudflare.com'
       }
+      return hosts[provider];
     };
     const getSubdomain = () => {
       switch (provider) {

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -192,12 +192,14 @@ describe('captcha rendering', function () {
   const HCAPTCHA_PROVIDER = 'hcaptcha';
   const FRIENDLY_CAPTCHA_PROVIDER = 'friendly_captcha';
   const ARKOSE_PROVIDER = 'arkose';
+  const AUTH0_V2_CAPTCHA_PROVIDER = 'auth0_v2';
 
   [
     RECAPTCHA_V2_PROVIDER,
     RECAPTCHA_ENTERPRISE_PROVIDER,
     HCAPTCHA_PROVIDER,
-    FRIENDLY_CAPTCHA_PROVIDER
+    FRIENDLY_CAPTCHA_PROVIDER,
+    AUTH0_V2_CAPTCHA_PROVIDER
   ].forEach(provider => {
     const getScript = () => {
       switch (provider) {
@@ -209,6 +211,8 @@ describe('captcha rendering', function () {
           return 'enterprise.js';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'widget.min.js';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'api.js';
       }
     };
     const getHostname = () => {
@@ -221,6 +225,8 @@ describe('captcha rendering', function () {
           return 'hcaptcha.com';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'jsdelivr.net';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'cloudflare.com';
       }
     };
     const getSubdomain = () => {
@@ -233,6 +239,8 @@ describe('captcha rendering', function () {
           return 'js';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'cdn';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'challenges';
       }
     };
     const getPath = () => {
@@ -245,6 +253,8 @@ describe('captcha rendering', function () {
           return '1';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'npm/friendly-challenge@0.9.12';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'turnstile/v0';
       }
     };
     const setMockGlobal = mock => {
@@ -260,6 +270,9 @@ describe('captcha rendering', function () {
           break;
         case FRIENDLY_CAPTCHA_PROVIDER:
           window.friendlyChallenge = mock;
+          break;
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          window.turnstile = mock;
           break;
       }
     };
@@ -303,8 +316,13 @@ describe('captcha rendering', function () {
           `${getSubdomain()}.${getHostname()}`
         );
         expect(scriptUrl.pathname).to.equal(`/${getPath()}/${getScript()}`);
-        if (provider !== FRIENDLY_CAPTCHA_PROVIDER) {
+        if (
+          provider !== FRIENDLY_CAPTCHA_PROVIDER &&
+          provider !== AUTH0_V2_CAPTCHA_PROVIDER
+        ) {
           expect(scriptUrl.query.hl).to.equal('en');
+        }
+        if (provider !== FRIENDLY_CAPTCHA_PROVIDER) {
           expect(scriptUrl.query).to.have.property('onload');
         }
       });
@@ -748,12 +766,14 @@ describe('passwordless captcha rendering', function () {
   const HCAPTCHA_PROVIDER = 'hcaptcha';
   const FRIENDLY_CAPTCHA_PROVIDER = 'friendly_captcha';
   const ARKOSE_PROVIDER = 'arkose';
+  const AUTH0_V2_CAPTCHA_PROVIDER = 'auth0_v2';
 
   [
     RECAPTCHA_V2_PROVIDER,
     RECAPTCHA_ENTERPRISE_PROVIDER,
     HCAPTCHA_PROVIDER,
-    FRIENDLY_CAPTCHA_PROVIDER
+    FRIENDLY_CAPTCHA_PROVIDER,
+    AUTH0_V2_CAPTCHA_PROVIDER
   ].forEach(provider => {
     const getScript = () => {
       switch (provider) {
@@ -765,6 +785,8 @@ describe('passwordless captcha rendering', function () {
           return 'enterprise.js';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'widget.min.js';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'api.js';
       }
     };
     const getHostname = () => {
@@ -777,6 +799,8 @@ describe('passwordless captcha rendering', function () {
           return 'hcaptcha.com';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'jsdelivr.net';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'cloudflare.com';
       }
     };
     const getSubdomain = () => {
@@ -789,6 +813,8 @@ describe('passwordless captcha rendering', function () {
           return 'js';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'cdn';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'challenges';
       }
     };
     const getPath = () => {
@@ -801,6 +827,8 @@ describe('passwordless captcha rendering', function () {
           return '1';
         case FRIENDLY_CAPTCHA_PROVIDER:
           return 'npm/friendly-challenge@0.9.12';
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          return 'turnstile/v0';
       }
     };
     const setMockGlobal = mock => {
@@ -816,6 +844,9 @@ describe('passwordless captcha rendering', function () {
           break;
         case FRIENDLY_CAPTCHA_PROVIDER:
           window.friendlyChallenge = mock;
+          break;
+        case AUTH0_V2_CAPTCHA_PROVIDER:
+          window.turnstile = mock;
           break;
       }
     };
@@ -861,8 +892,13 @@ describe('passwordless captcha rendering', function () {
           `${getSubdomain()}.${getHostname()}`
         );
         expect(scriptUrl.pathname).to.equal(`/${getPath()}/${getScript()}`);
-        if (provider !== FRIENDLY_CAPTCHA_PROVIDER) {
+        if (
+          provider !== FRIENDLY_CAPTCHA_PROVIDER &&
+          provider !== AUTH0_V2_CAPTCHA_PROVIDER
+        ) {
           expect(scriptUrl.query.hl).to.equal('en');
+        }
+        if (provider !== FRIENDLY_CAPTCHA_PROVIDER) {
           expect(scriptUrl.query).to.have.property('onload');
         }
       });


### PR DESCRIPTION
### Changes
Added support for Auth0 v2 (Cloudflare turnstile) captcha provider.

### References
https://auth0team.atlassian.net/browse/IAMRISK-2916

### Testing
tested locally with server:
![Screenshot 2023-12-11 at 1 07 25 PM](https://github.com/auth0/auth0.js/assets/117461691/6e1ca715-71da-4b8d-8c8c-23ab96e0f59e)
![Screenshot 2023-12-11 at 1 07 09 PM](https://github.com/auth0/auth0.js/assets/117461691/77d53627-030e-49f8-ad20-53ea836b6a12)

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
