### PR TITLE
Making release workflow reusable

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -16,9 +16,6 @@ permissions:
   contents: write
   id-token: write # For publishing to npm using --provenance
 
-env:
-  NODE_VERSION: 18
-
 ### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
 ### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
 

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,83 @@
+name: Create GitHub Release
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+    secrets:
+      github-token:
+        required: true
+      npm-token:
+        required: true
+
+permissions:
+  contents: write
+  id-token: write # For publishing to npm using --provenance
+
+env:
+  NODE_VERSION: 18
+
+### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
+### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Get the version from the branch name
+      - id: get_version
+        uses: ./.github/actions/get-version
+
+      # Get the prerelease flag from the branch name
+      - id: get_prerelease
+        uses: ./.github/actions/get-prerelease
+        with:
+          version: ${{ steps.get_version.outputs.version }}
+
+      # Get the release notes
+      # This will expose the release notes as env.RELEASE_NOTES
+      - id: get_release_notes
+        uses: ./.github/actions/get-release-notes
+        with:
+          token: ${{ secrets.github-token }}
+          version: ${{ steps.get_version.outputs.version }}
+          repo_owner: ${{ github.repository_owner }}
+          repo_name: ${{ github.event.repository.name }}
+
+      # Check if the tag already exists
+      - id: tag_exists
+        uses: ./.github/actions/tag-exists
+        with:
+          tag: ${{ steps.get_version.outputs.version }}
+          token: ${{ secrets.github-token }}
+
+      # If the tag already exists, exit with an error
+      - if: steps.tag_exists.outputs.exists == 'true'
+        run: exit 1
+
+      # Publish the release to our package manager
+      - uses: ./.github/actions/publish-package
+        with:
+          node-version: ${{ inputs.node-version }}
+          version: ${{ steps.get_version.outputs.version }}
+          npm-token: ${{ secrets.npm-token }}
+
+      # Create a release for the tag
+      - uses: ./.github/actions/release-create
+        with:
+          token: ${{ secrets.github-token }}
+          name: ${{ steps.get_version.outputs.version }}
+          body: ${{ steps.get_release_notes.outputs.release-notes }}
+          tag: ${{ steps.get_version.outputs.version }}
+          commit: ${{ github.sha }}
+          prerelease: ${{ steps.get_prerelease.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
       - closed
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write # For publishing to npm using --provenance
-
 env:
   NODE_VERSION: 18
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,60 +18,9 @@ env:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
-    runs-on: ubuntu-latest
-    environment: release
-
-    steps:
-      # Checkout the code
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      # Get the version from the branch name
-      - id: get_version
-        uses: ./.github/actions/get-version
-
-      # Get the prerelease flag from the branch name
-      - id: get_prerelease
-        uses: ./.github/actions/get-prerelease
-        with:
-          version: ${{ steps.get_version.outputs.version }}
-
-      # Get the release notes
-      # This will expose the release notes as env.RELEASE_NOTES
-      - id: get_release_notes
-        uses: ./.github/actions/get-release-notes
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ steps.get_version.outputs.version }}
-          repo_owner: ${{ github.repository_owner }}
-          repo_name: ${{ github.event.repository.name }}
-
-      # Check if the tag already exists
-      - id: tag_exists
-        uses: ./.github/actions/tag-exists
-        with:
-          tag: ${{ steps.get_version.outputs.version }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # If the tag already exists, exit with an error
-      - if: steps.tag_exists.outputs.exists == 'true'
-        run: exit 1
-
-      # Publish the release to our package manager
-      - uses: ./.github/actions/publish-package
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          version: ${{ steps.get_version.outputs.version }}
-          npm-token: ${{ secrets.NPM_TOKEN }}
-
-      # Create a release for the tag
-      - uses: ./.github/actions/release-create
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: ${{ steps.get_version.outputs.version }}
-          body: ${{ steps.get_release_notes.outputs.release-notes }}
-          tag: ${{ steps.get_version.outputs.version }}
-          commit: ${{ github.sha }}
-          prerelease: ${{ steps.get_prerelease.outputs.prerelease }}
+    uses: ./.github/workflows/npm-release.yml
+    with:
+      node-version: ${{ env.NODE_VERSION }}
+    secrets:
+      npm-token: ${{ secrets.NPM_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes
This PR will move the bulk of release workflow into a reusable workflow called npm-release.yml.

This will help us when writing publish workflows for new Languages/Frameworks like Java or Python.

We just need to replace the workflow in release.yml
