### PR TITLE
Rename publish action to npm-publish and add require-build

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -1,4 +1,4 @@
-name: Publish release to package manager
+name: Publish release to npm
 
 inputs:
   node-version:
@@ -7,6 +7,8 @@ inputs:
     required: true
   version:
     required: true
+  require-build:
+    default: true
   release-directory:
     default: './'
 
@@ -24,10 +26,15 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Install dependencies
+      if: inputs.require-build == 'true'
+      shell: bash
+      run: npm ci --include=dev
+
     - name: Build package
-      uses: ./.github/actions/build
-      with:
-        node: ${{ inputs.node-version }}
+      if: inputs.require-build == 'true'
+      shell: bash
+      run: npm run build
 
     - name: Publish release to NPM
       shell: bash

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -6,6 +6,8 @@ on:
       node-version:
         required: true
         type: string
+      require-build:
+        default: true
     secrets:
       github-token:
         required: true
@@ -57,10 +59,11 @@ jobs:
       - if: steps.tag_exists.outputs.exists == 'true'
         run: exit 1
 
-      # Publish the release to our package manager
-      - uses: ./.github/actions/publish-package
+      # Publish the release to npm
+      - uses: ./.github/actions/npm-publish
         with:
           node-version: ${{ inputs.node-version }}
+          require-build: ${{ inputs.require-build }}
           version: ${{ steps.get_version.outputs.version }}
           npm-token: ${{ secrets.npm-token }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,9 @@ permissions:
   contents: write
   id-token: write # For publishing to npm using --provenance
 
-### TODO: Replace instances of './.github/actions/' w/ `auth0/dx-sdk-actions/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
-### TODO: Also remove `get-prerelease`, `get-version`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
+### TODO: Replace instances of './.github/workflows/' w/ `auth0/dx-sdk-actions/workflows/` and append `@latest` after the common `dx-sdk-actions` repo is made public.
+### TODO: Also remove `get-prerelease`, `get-release-notes`, `get-version`, `npm-publish`, `release-create`, and `tag-exists` actions from this repo's .github/actions folder once the repo is public.
+### TODO: Also remove `npm-release` workflow from this repo's .github/workflows folder once the repo is public.
 
 jobs:
   release:
@@ -21,3 +22,4 @@ jobs:
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
+      require-build: true


### PR DESCRIPTION
### Changes

- renames `publish-package` action to `npm-publish`
- add `require-build` input to `npm-publish` to support skipping build
- no longer rely on the build action but inline build script in `npm-publish`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
