### PR TITLE
fix: ignore the https protocol while comparing domains for username/password logins

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -400,10 +400,10 @@ WebAuth.prototype.validateAuthenticationResponse = function (
               return callback(
                 error.invalidToken(
                   'Organization Id (org_id) claim value mismatch in the ID token; expected "' +
-                    transactionOrganization +
-                    '", found "' +
-                    payload.org_id +
-                    '"'
+                  transactionOrganization +
+                  '", found "' +
+                  payload.org_id +
+                  '"'
                 )
               );
             }
@@ -420,10 +420,10 @@ WebAuth.prototype.validateAuthenticationResponse = function (
               return callback(
                 error.invalidToken(
                   'Organization Name (org_name) claim value mismatch in the ID token; expected "' +
-                    transactionOrganization +
-                    '", found "' +
-                    payload.org_name +
-                    '"'
+                  transactionOrganization +
+                  '", found "' +
+                  payload.org_name +
+                  '"'
                 )
               );
             }
@@ -944,8 +944,9 @@ WebAuth.prototype.login = function (options, cb) {
 
   params = this.transactionManager.process(params);
 
+  optionsDomainWithoutProtocol = this.baseOptions.domain.replace("https://", "")
   var isHostedLoginPage =
-    windowHelper.getWindow().location.host === this.baseOptions.domain;
+    windowHelper.getWindow().location.host === optionsDomainWithoutProtocol;
 
   if (isHostedLoginPage) {
     params.connection = params.realm;


### PR DESCRIPTION
### Changes

When using the webAuth.login fn, it always uses the cross origin authentication flow if the `domain` in the options contains the protocol (`https://`). Asking users to remove it from the options provided is one way to go, but feels like this is something the library can solve

### References

Please include relevant links supporting this change such as a:

- community post:
https://community.auth0.com/t/creating-a-custom-login-page-under-universal-login/96419/2

### Testing

Not really relevant for this change

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
