### PR TITLE
fix: Add missing captcha arg to signup functions

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -33,6 +33,7 @@ function DBConnection(request, options) {
  * @param {String} [options.picture] A URI pointing to the user's picture.
  * @param {String} options.connection name of the connection where the user will be created
  * @param {Object} [options.user_metadata] additional signup attributes used for creating the user. Will be stored in `user_metadata`
+ * @param {String} [options.captcha] the attempted solution for the captcha, if one was presented
  * @param {signUpCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  * @ignore

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -792,6 +792,7 @@ WebAuth.prototype.passwordlessStart = function (options, cb) {
  * @param {String} [options.name] The user's full name.
  * @param {String} [options.nickname] The user's nickname.
  * @param {String} [options.picture] A URI pointing to the user's picture.
+ * @param {String} [options.captcha] the attempted solution for the captcha, if one was presented
  * @param {signUpCallback} cb
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  * @memberof WebAuth.prototype


### PR DESCRIPTION
### Changes

- Add `options.captcha` arg to `DBConnection.prototype.signup` function
- Add `options.captcha` arg to `WebAuth.prototype.signup` function

### References

`Redirect.prototype.signupAndLogin` already has this arg and passes it through to `DBConnection.prototype.signup` which is how I discovered that this was supported. Seems like the underlying functions and backend supports this arg. I've copied the JSDoc from `signupAndLogin` to ensure consistency.

### Testing

I'm unsure of how to add an automated test to ensure that this works, however I have tested it in a project and passing through `options.captcha` with a real captcha value worked with an Auth0 tenant with Bot Protection enabled.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
