### PR TITLE
[IAMRISK-3339] Add call to get captcha for reset password

### DIFF
--- a/src/authentication/db-connection.js
+++ b/src/authentication/db-connection.js
@@ -37,7 +37,7 @@ function DBConnection(request, options) {
  * @see   {@link https://auth0.com/docs/api/authentication#signup}
  * @ignore
  */
-DBConnection.prototype.signup = function(options, cb) {
+DBConnection.prototype.signup = function (options, cb) {
   var url;
   var body;
   var metadata;
@@ -96,7 +96,7 @@ DBConnection.prototype.signup = function(options, cb) {
  * @see   {@link https://auth0.com/docs/api/authentication#change-password}
  * @ignore
  */
-DBConnection.prototype.changePassword = function(options, cb) {
+DBConnection.prototype.changePassword = function (options, cb) {
   var url;
   var body;
 
@@ -113,8 +113,8 @@ DBConnection.prototype.changePassword = function(options, cb) {
   url = urljoin(this.baseOptions.rootUrl, 'dbconnections', 'change_password');
 
   body = objectHelper
-    .merge(this.baseOptions, ['clientID'])
-    .with(options, ['email', 'connection']);
+    .merge(this.baseOptions, ['clientID', 'state'])
+    .with(options, ['email', 'connection', 'captcha']);
 
   body = objectHelper.toSnakeCase(body, ['auth0Client']);
 
@@ -122,6 +122,21 @@ DBConnection.prototype.changePassword = function(options, cb) {
     .post(url)
     .send(body)
     .end(responseHandler(cb));
+};
+
+DBConnection.prototype.getChallenge = function (cb) {
+  assert.check(cb, { type: 'function', message: 'cb parameter is not valid' });
+
+  if (!this.baseOptions.state) {
+    return cb();
+  }
+
+  var url = urljoin(this.baseOptions.rootUrl, 'resetpassword', 'challenge');
+
+  return this.request
+    .post(url)
+    .send({ state: this.baseOptions.state })
+    .end(responseHandler(cb, { ignoreCasing: true }));
 };
 
 export default DBConnection;

--- a/test/authentication/db-connection.test.js
+++ b/test/authentication/db-connection.test.js
@@ -8,9 +8,9 @@ import RequestBuilder from '../../src/helper/request-builder';
 import Authentication from '../../src/authentication';
 var telemetryInfo = new RequestBuilder({}).getTelemetryData();
 
-describe('auth0.authentication', function() {
-  context('dbConnection signup options', function() {
-    before(function() {
+describe('auth0.authentication', function () {
+  context('dbConnection signup options', function () {
+    before(function () {
       this.auth0 = new Authentication({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -20,62 +20,62 @@ describe('auth0.authentication', function() {
       });
     });
 
-    it('should check that options is passed', function() {
+    it('should check that options is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.signup();
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('options parameter is not valid');
       });
     });
 
-    it('should check that options.connection is passed', function() {
+    it('should check that options.connection is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.signup({});
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('connection option is required');
       });
     });
 
-    it('should check that options.email is passed', function() {
+    it('should check that options.email is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.signup({ connection: 'bla' });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('email option is required');
       });
     });
 
-    it('should check that options.password is passed', function() {
+    it('should check that options.password is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.signup({ connection: 'bla', email: 'blabla' });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('password option is required');
       });
     });
 
-    it('should check that cb is valid', function() {
+    it('should check that cb is valid', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.signup({
           connection: 'bla',
           email: 'blabla',
           password: '123456'
         });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('cb parameter is not valid');
       });
     });
 
-    context('additional fields', function() {
-      afterEach(function() {
+    context('additional fields', function () {
+      afterEach(function () {
         request.post.restore();
       });
 
-      it('should send metadata on signup', function(done) {
-        sinon.stub(request, 'post').callsFake(function(url) {
+      it('should send metadata on signup', function (done) {
+        sinon.stub(request, 'post').callsFake(function (url) {
           expect(url).to.be('https://me.auth0.com/dbconnections/signup');
           expect;
           return new RequestMock({
@@ -94,7 +94,7 @@ describe('auth0.authentication', function() {
               'Content-Type': 'application/json',
               'Auth0-Client': telemetryInfo
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   email: 'the email'
@@ -114,7 +114,7 @@ describe('auth0.authentication', function() {
               lastName: 'De Coninck'
             }
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               email: 'the email'
@@ -124,8 +124,8 @@ describe('auth0.authentication', function() {
         );
       });
 
-      it('should send metadata on signup when using camel case', function(done) {
-        sinon.stub(request, 'post').callsFake(function(url) {
+      it('should send metadata on signup when using camel case', function (done) {
+        sinon.stub(request, 'post').callsFake(function (url) {
           expect(url).to.be('https://me.auth0.com/dbconnections/signup');
           expect;
           return new RequestMock({
@@ -145,7 +145,7 @@ describe('auth0.authentication', function() {
               'Content-Type': 'application/json',
               'Auth0-Client': telemetryInfo
             },
-            cb: function(cb) {
+            cb: function (cb) {
               cb(null, {
                 body: {
                   email: 'the email'
@@ -166,7 +166,7 @@ describe('auth0.authentication', function() {
               last_location: 'Mexico'
             }
           },
-          function(err, data) {
+          function (err, data) {
             expect(err).to.be(null);
             expect(data).to.eql({
               email: 'the email'
@@ -178,8 +178,8 @@ describe('auth0.authentication', function() {
     });
   });
 
-  context('change password options', function() {
-    before(function() {
+  context('change password options', function () {
+    before(function () {
       this.auth0 = new Authentication({
         domain: 'me.auth0.com',
         clientID: '...',
@@ -189,43 +189,133 @@ describe('auth0.authentication', function() {
       });
     });
 
-    it('should check that options is passed', function() {
+    it('should check that options is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.changePassword();
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('options parameter is not valid');
       });
     });
 
-    it('should check that options.connection is passed', function() {
+    it('should check that options.connection is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.changePassword({});
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('connection option is required');
       });
     });
 
-    it('should check that options.email is passed', function() {
+    it('should check that options.email is passed', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.changePassword({ connection: 'bla' });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('email option is required');
       });
     });
 
-    it('should check that cb is valid', function() {
+    it('should check that cb is valid', function () {
       var _this = this;
-      expect(function() {
+      expect(function () {
         _this.auth0.dbConnection.changePassword({
           connection: 'bla',
           email: 'blabla',
           password: '123456'
         });
-      }).to.throwException(function(e) {
+      }).to.throwException(function (e) {
         expect(e.message).to.be('cb parameter is not valid');
+      });
+    });
+  });
+
+  context('dbConnection getChallenge', function () {
+    context('when the client does not have state', function () {
+      before(function () {
+        this.auth0 = new Authentication(this.webAuthSpy, {
+          domain: 'me.auth0.com',
+          clientID: '...',
+          redirectUri: 'http://page.com/callback',
+          responseType: 'code',
+          _sendTelemetry: false
+        });
+      });
+
+      it('should return nothing', function (done) {
+        this.auth0.dbConnection.getChallenge((err, challenge) => {
+          expect(err).to.not.be.ok();
+          expect(challenge).to.not.be.ok();
+          done();
+        });
+      });
+    });
+
+    context('when the client has state', function () {
+      before(function () {
+        this.auth0 = new Authentication(this.webAuthSpy, {
+          domain: 'me.auth0.com',
+          clientID: '...',
+          redirectUri: 'http://page.com/callback',
+          responseType: 'code',
+          _sendTelemetry: false,
+          state: '123abc'
+        });
+      });
+
+      afterEach(function () {
+        request.post.restore();
+      });
+
+      it('should post state and returns the image/type', function (done) {
+        sinon.stub(request, 'post').callsFake(function (url) {
+          expect(url).to.be('https://me.auth0.com/resetpassword/challenge');
+          return new RequestMock({
+            body: {
+              state: '123abc'
+            },
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            cb: function (cb) {
+              cb(null, {
+                body: {
+                  image: 'svg+yadayada',
+                  type: 'code'
+                }
+              });
+            }
+          });
+        });
+
+        this.auth0.dbConnection.getChallenge((err, challenge) => {
+          expect(err).to.not.be.ok();
+          expect(challenge.image).to.be('svg+yadayada');
+          expect(challenge.type).to.be('code');
+          done();
+        });
+      });
+
+      it('should return the error if network fails', function (done) {
+        sinon.stub(request, 'post').callsFake(function (url) {
+          expect(url).to.be('https://me.auth0.com/resetpassword/challenge');
+          return new RequestMock({
+            body: {
+              state: '123abc'
+            },
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            cb: function (cb) {
+              cb(new Error('error error error'));
+            }
+          });
+        });
+
+        this.auth0.dbConnection.getChallenge((err, challenge) => {
+          expect(err.original.message).to.equal('error error error');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
### Changes

Adds an API call to get a captcha challenge for reset password flow.

### References

https://auth0team.atlassian.net/browse/IAMRISK-3339

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
