### PR TITLE
Arkose: run() not reset() on repeat attempts to authenticate

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -231,7 +231,7 @@ function handleCaptchaProvider(element, options, challenge, done) {
     globalForCaptchaProvider(challenge.provider)
   ) {
     setValue();
-    globalForCaptchaProvider(challenge.provider).reset();
+    globalForCaptchaProvider(challenge.provider).run();
     return;
   } else if (widgetId) {
     setValue();


### PR DESCRIPTION
### Changes

Calling `reset()` instead of `run()` on the Arkose provider object breaks callbacks which prevents repeat authentication attempts with the same Auth0.js object. It now calls `run()` instead of `reset()`.

> Side note: As a customer, I found the JSDocs and Auth0 Docs rather lacking while trying to debug this issue. Parameters aren't present, just `<optional>` which is extraordinarily frustrating. There is also no information about behaviour, scope, or parameters in regards to `triggerCaptcha()`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
