### PR TITLE
chore(deps): Upgrade `superagent` to v9.X

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "js-cookie": "^2.2.0",
         "minimist": "^1.2.5",
         "qs": "^6.10.1",
-        "superagent": "^7.1.5",
+        "superagent": "^9.0.2",
         "url-join": "^4.0.1",
         "winchan": "^0.2.2"
       },
@@ -6216,14 +6216,13 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -7001,7 +7000,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/inquirer": {
       "version": "6.5.2",
@@ -13012,6 +13012,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -13019,7 +13020,8 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -13180,68 +13182,23 @@
       }
     },
     "node_modules/superagent": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
-      "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
       "dependencies": {
         "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.3",
+        "cookiejar": "^2.1.4",
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.0.1",
+        "formidable": "^3.5.1",
         "methods": "^1.1.2",
-        "mime": "^2.5.0",
-        "qs": "^6.10.3",
-        "readable-stream": "^3.6.0",
-        "semver": "^7.3.7"
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
-    },
-    "node_modules/superagent/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/superagent/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
-      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/superagent/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/supports-color": {
       "version": "2.0.0",
@@ -14053,7 +14010,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/uuid": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "js-cookie": "^2.2.0",
     "minimist": "^1.2.5",
     "qs": "^6.10.1",
-    "superagent": "^7.1.5",
+    "superagent": "^9.0.2",
     "url-join": "^4.0.1",
     "winchan": "^0.2.2"
   },


### PR DESCRIPTION
### Changes

Superagent has a patch for a publicly announced vulnerability now available in version `9.X`. This PR updates the `superagent` dependency to the latest version.

```
warning auth0-js > superagent@7.1.6: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net
```

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
