### PR TITLE
Allow passing sandbox attributes to iframes

### DIFF
--- a/src/helper/iframe-handler.js
+++ b/src/helper/iframe-handler.js
@@ -11,6 +11,8 @@ function IframeHandler(options) {
   this._destroyTimeout = null;
   this.transientMessageEventListener = null;
   this.proxyEventListener = null;
+  this.sandbox = options.sandbox == null ?
+    'allow-same-origin allow-scripts' : options.sandbox;
   // If no event identifier specified, set default
   this.eventValidator = options.eventValidator || {
     isValid: function() {
@@ -57,6 +59,7 @@ IframeHandler.prototype.init = function() {
   _window.document.body.appendChild(this.iframe);
 
   this.iframe.src = this.url;
+  this.iframe.sandbox = this.sandbox;
 
   this.timeoutHandle = setTimeout(function() {
     _this.timeoutHandler();

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -575,6 +575,7 @@ WebAuth.prototype.validateToken = function (token, nonce, cb) {
  * @param {String} [options.postMessageOrigin] origin of redirectUri to expect postMessage response from.  Defaults to the origin of the receiving window. Only used if usePostMessage is truthy.
  * @param {String} [options.timeout] value in milliseconds used to timeout when the `/authorize` call is failing as part of the silent authentication with postmessage enabled due to a configuration.
  * @param {Boolean} [options.usePostMessage] use postMessage to comunicate between the silent callback and the SPA. When false the SDK will attempt to parse the url hash should ignore the url hash and no extra behaviour is needed
+ * @param {String} [options.sandbox] attribute values for the hidden iframe. Defaults to `allow-same-origin allow-scripts`
  * @param {authorizeCallback} cb
  * @see {@link https://auth0.com/docs/api/authentication#authorize-client}
  * @memberof WebAuth.prototype
@@ -586,6 +587,7 @@ WebAuth.prototype.renewAuth = function (options, cb) {
   var postMessageOrigin =
     options.postMessageOrigin || windowHelper.getWindow().origin;
   var timeout = options.timeout;
+  var sandbox = options.sandbox;
   var _this = this;
 
   var params = objectHelper
@@ -625,7 +627,8 @@ WebAuth.prototype.renewAuth = function (options, cb) {
     authenticationUrl: this.client.buildAuthorizeUrl(params),
     postMessageDataType: postMessageDataType,
     postMessageOrigin: postMessageOrigin,
-    timeout: timeout
+    timeout: timeout,
+    sandbox: sandbox
   });
 
   handler.login(usePostMessage, function (err, hash) {
@@ -675,6 +678,7 @@ WebAuth.prototype.renewAuth = function (options, cb) {
  * @param {String} [options.audience] identifier of the resource server who will consume the access token issued after Auth
  * @param {String} [options.timeout] value in milliseconds used to timeout when the `/authorize` call is failing as part of the silent authentication with postmessage enabled due to a configuration.
  * @param {String} [options.organization] the id or name of an organization to log in to
+ * @param {String} [options.sandbox] attribute values for the hidden iframe. Defaults to `allow-same-origin allow-scripts`
  * @param {checkSessionCallback} cb
  * @see {@link https://auth0.com/docs/libraries/auth0js/v9#using-checksession-to-acquire-new-tokens}
  * @memberof WebAuth.prototype

--- a/src/web-auth/silent-authentication-handler.js
+++ b/src/web-auth/silent-authentication-handler.js
@@ -6,6 +6,7 @@ function SilentAuthenticationHandler(options) {
   this.timeout = options.timeout || 60 * 1000;
   this.handler = null;
   this.postMessageDataType = options.postMessageDataType || false;
+  this.sandbox = options.sandbox;
 
   // prefer origin from options, fallback to origin from browser, and some browsers (for example MS Edge) don't support origin; fallback to construct origin manually
   this.postMessageOrigin =
@@ -40,7 +41,8 @@ SilentAuthenticationHandler.prototype.login = function(
         '#error=timeout&error_description=Timeout+during+authentication+renew.'
       );
     },
-    usePostMessage: usePostMessage || false
+    usePostMessage: usePostMessage || false,
+    sandbox: this.sandbox
   });
 
   this.handler.init();

--- a/src/web-auth/web-message-handler.js
+++ b/src/web-auth/web-message-handler.js
@@ -26,7 +26,8 @@ function runWebMessageFlow(authorizeUrl, options, callback) {
         error_description: 'Timeout during executing web_message communication',
         state: options.state
       });
-    }
+    },
+    sandbox: options.sandbox
   });
   handler.init();
 }

--- a/test/helper/iframe-handler.test.js
+++ b/test/helper/iframe-handler.test.js
@@ -121,6 +121,20 @@ describe('helpers iframeHandler', function() {
       expect(windowHelper.getWindow().document.body);
       expect(iframe.src).to.be('my-url');
       expect(iframe.style.display).to.be('none');
+      expect(iframe.sandbox).to.be('allow-same-origin allow-scripts');
+    });
+
+    it('should create a hidden iframe with specific sandbox attributes', function () {
+      var iframe = stubWindow('load');
+      var iframeHandler = new IframeHandler({
+        url: 'my-url',
+        callback: function() {},
+        sandbox: 'allow-same-origin'
+      });
+
+      iframeHandler.init();
+
+      expect(iframe.sandbox).to.be('allow-same-origin');
     });
 
     it('should callback after a timeout', function() {

--- a/test/web-auth/silent-authentication-handler.test.js
+++ b/test/web-auth/silent-authentication-handler.test.js
@@ -340,5 +340,14 @@ describe('handlers silent-authentication-handler', function() {
 
       expect(sah.postMessageOrigin).to.be('https://unit-test');
     });
+
+    it('sets sandbox from parameter', function () {
+      var expectedSandbox = 'unit-test-sandbox';
+      var param = { sandbox: expectedSandbox };
+
+      var sah = new SilentAuthenticationHandler(param);
+
+      expect(sah.sandbox).to.be(expectedSandbox);
+    });
   });
 });

--- a/test/web-auth/web-auth.test.js
+++ b/test/web-auth/web-auth.test.js
@@ -242,12 +242,14 @@ describe('auth0.WebAuth', function () {
         webAuth.renewAuth(options, function (err, data) { });
       });
 
-      it('should use postMessageOrigin if provided', function (done) {
+      it('should use postMessageOrigin and sandbox if provided', function (done) {
         var postMessageOrigin = 'foobar1';
+        var sandbox = 'allow-same-origin'
         sinon
           .stub(SilentAuthenticationHandler, 'create')
           .callsFake(function (options) {
             expect(options.postMessageOrigin).to.eql(postMessageOrigin);
+            expect(options.sandbox).to.eql(sandbox);
             done();
             return {
               login: function () { }
@@ -267,7 +269,8 @@ describe('auth0.WebAuth', function () {
         var options = {
           nonce: '123',
           state: '456',
-          postMessageOrigin: postMessageOrigin
+          postMessageOrigin: postMessageOrigin,
+          sandbox: sandbox
         };
 
         webAuth.renewAuth(options, function (err, data) { });


### PR DESCRIPTION
### Changes

Allow passing [sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox) to the hidden iframe when using `renewAuth()`. This is desired when it's not necessary to execute javascript code in the iframe if all what's wanted is to extract url hash as soon as the page is returned:

```js
renewAuth({ usePostMessage: false, sandbox: 'allow-same-origin' }, e => {});
```

It is also a security measure to tighten the resources which can be accessed. The default value here is `"allow-same-origin allow-scripts"`, which should ensure most of the existing scenarios work.

### References

NA

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
