### PR TITLE
fix: Enforce organization validation in HS256 token fallback path

### DIFF
--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -501,6 +501,52 @@ WebAuth.prototype.validateAuthenticationResponse = function (
           if (errUserInfo) {
             return callback(errUserInfo);
           }
+
+          // Verify the organization for HS256 tokens (same check as RS256 path)
+          if (transactionOrganization) {
+            if (transactionOrganization.indexOf('org_') === 0) {
+              if (!profile.org_id) {
+                return callback(
+                  error.invalidToken(
+                    'Organization Id (org_id) claim must be a string present in the ID token'
+                  )
+                );
+              }
+
+              if (profile.org_id !== transactionOrganization) {
+                return callback(
+                  error.invalidToken(
+                    'Organization Id (org_id) claim value mismatch in the ID token; expected "' +
+                    transactionOrganization +
+                    '", found "' +
+                    profile.org_id +
+                    '"'
+                  )
+                );
+              }
+            } else {
+              if (!profile.org_name) {
+                return callback(
+                  error.invalidToken(
+                    'Organization Name (org_name) claim must be a string present in the ID token'
+                  )
+                );
+              }
+
+              if (profile.org_name !== transactionOrganization.toLowerCase()) {
+                return callback(
+                  error.invalidToken(
+                    'Organization Name (org_name) claim value mismatch in the ID token; expected "' +
+                    transactionOrganization +
+                    '", found "' +
+                    profile.org_name +
+                    '"'
+                  )
+                );
+              }
+            }
+          }
+
           return callback(null, profile);
         }
       );


### PR DESCRIPTION
## Summary

The HS256 fallback path in `validateAuthenticationResponse` (`src/web-auth/index.js`) **skips organization validation entirely**, while the RS256 path correctly enforces it. This means when an HS256-signed ID token is processed and the `/userinfo` endpoint is used to build the payload, the `org_id` / `org_name` claims from the `/userinfo` response are never checked against the `transactionOrganization` value stored during the `/authorize` request.

## Root Cause

In `WebAuth.prototype.validateAuthenticationResponse`, there are two branches:

1. **RS256 (successful validation)** — lines 389-429 check `payload.org_id` or `payload.org_name` against `transactionOrganization` before accepting the token.
2. **HS256 fallback (validation error + HS256 alg detected)** — lines 467-505 decode the token, verify the nonce, call `/userinfo`, and then pass the `/userinfo` profile directly to `callback(null, profile)` **without any organization check**.

The organization check was added to the RS256 path but was never replicated in the HS256 fallback path.

## Impact

When all of the following conditions are met:
- The Auth0 application is configured to issue **HS256-signed ID tokens** (non-default; Auth0 defaults to RS256)
- The application uses the **Organizations** feature and passes `organization` during authentication
- The `responseType` includes both `token` and `id_token`

...the SDK will accept a `/userinfo` response without verifying that the user's organization matches the organization the application expected. This is a **defense-in-depth gap** — the server-side `/authorize` endpoint does enforce organization constraints, but the client-side SDK should also validate as a second layer.

## Fix

Added the same `transactionOrganization` validation logic (checking `org_id` for IDs starting with `org_`, and `org_name` for organization names with case-insensitive comparison) to the HS256 fallback path, executed after `/userinfo` returns successfully and before accepting the profile.

## Tests Added

5 new test cases under "Organization validation with HS256 tokens":
- org_id matches transaction organization (success)
- org_id does not match transaction organization (rejection)
- org_id missing from /userinfo when expected (rejection)
- org_name matches transaction organization (success, case-insensitive)
- org_name does not match transaction organization (rejection)

All 107 tests pass.

## Files Changed

- `src/web-auth/index.js` — Added organization validation after `/userinfo` callback in HS256 path
- `test/web-auth/web-auth.test.js` — Added 5 test cases for HS256 organization validation

## Security Contact

Reported by: **hi@harshinsecurity.in**
