### PR TITLE
feat(captcha): allow for passing appearance to options

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -25,6 +25,7 @@ var MAX_RETRY = 3;
 
 var defaults = {
   lang: 'en',
+  appearance: 'always',
   templates: {
     auth0: function (challenge) {
       var message =
@@ -354,6 +355,7 @@ function handleCaptchaProvider(element, options, challenge) {
         if (challenge.provider === AUTH0_V2_CAPTCHA_PROVIDER) {
           retryCount = 0;
           renderParams.language = options.lang;
+          renderParams.appearance = options.appearance;
           renderParams.theme = 'light';
           renderParams.retry = 'never';
           renderParams['response-field'] = false;
@@ -395,6 +397,7 @@ function handleCaptchaProvider(element, options, challenge) {
  * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for recaptcha
+ * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
  * @param {Function} [callback] An optional callback called after captcha is loaded
  * @ignore
  */
@@ -457,6 +460,5 @@ function render(auth0Client, flow, element, options, callback) {
     getValue: getValue
   };
 }
-
 
 export default { render: render, Flow: Flow };

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -2,7 +2,7 @@
 import Authentication from '../authentication';
 import object from '../helper/object';
 
-var noop = function () { };
+var noop = function () {};
 var captchaSolved = noop;
 var done = noop;
 var captchaReloaded = false;
@@ -26,6 +26,7 @@ var MAX_RETRY = 3;
 var defaults = {
   lang: 'en',
   appearance: 'always',
+  successCallback: noop,
   templates: {
     auth0: function (challenge) {
       var message =
@@ -342,7 +343,12 @@ function handleCaptchaProvider(element, options, challenge) {
         done();
       } else {
         var renderParams = {
-          callback: setValue,
+          callback: function (token) {
+            setValue(token);
+            if (challenge.provider === AUTH0_V2_CAPTCHA_PROVIDER) {
+              options.successCallback();
+            }
+          },
           'expired-callback': function () {
             setValue();
           },
@@ -397,7 +403,8 @@ function handleCaptchaProvider(element, options, challenge) {
  * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for recaptcha
- * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
+ * @param {String} [options.appearance=always] When the widget is visible: 'always', 'interaction-only'. Only applies to the auth0_v2 provider.
+ * @param {Function} [options.successCallback] A callback function that is called when the captcha is solved successfully. Only applies to the auth0_v2 provider.
  * @param {Function} [callback] An optional callback called after captcha is loaded
  * @ignore
  */

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1103,6 +1103,7 @@ WebAuth.prototype.passwordlessVerify = function (options, cb) {
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
+ * @param {Function} [options.successCallback] A callback function that is called when the captcha is solved successfully. Only applies to the auth0_v2 provider.\
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded
  * @memberof WebAuth.prototype
  */
@@ -1127,6 +1128,8 @@ WebAuth.prototype.renderCaptcha = function (element, options, callback) {
  * @param {Function} [options.templates.arkose] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
+ * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
+ * @param {Function} [options.successCallback] A callback function that is called when the captcha is solved successfully. Only applies to the auth0_v2 provider.
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded
  * @memberof WebAuth.prototype
@@ -1186,6 +1189,8 @@ WebAuth.prototype.renderPasswordlessCaptcha = function (
  * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
+ * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
+ * @param {Function} [options.successCallback] A callback function that is called when the captcha is solved successfully. Only applies to the auth0_v2 provider.
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded
  * @memberof WebAuth.prototype
  */

--- a/src/web-auth/index.js
+++ b/src/web-auth/index.js
@@ -1102,6 +1102,7 @@ WebAuth.prototype.passwordlessVerify = function (options, cb) {
  * @param {Function} [options.templates.auth0_v2] template function receiving the challenge and returning a string
  * @param {Function} [options.templates.error] template function returning a custom error message when the challenge could not be fetched, receives the error as first argument
  * @param {String} [options.lang=en] the ISO code of the language for the captcha provider
+ * @param {String} [options.appearance=always] When the widget is visible: 'always', 'execute', 'interaction-only'
  * @param {captchaLoadedCallback} [callback] An optional callback called after captcha is loaded
  * @memberof WebAuth.prototype
  */

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -450,6 +450,88 @@ describe('captcha rendering', function () {
             expect(finalRetry).to.equal(true);
             expect(input.value).to.equal('BYPASS_CAPTCHA');
           });
+
+          it('should pass the default appearance option to turnstile', function () {
+            expect(renderOptions.appearance).to.equal('always');
+          });
+
+          it('should pass a custom appearance option to turnstile', function () {
+            const { window: customWindow } = new JSDOM(
+              '<body><div class="captcha" /></body>'
+            );
+            const customElement =
+              customWindow.document.querySelector('.captcha');
+            global.window = customWindow;
+            let customRenderOptions;
+            customWindow.turnstile = {
+              render(element, options) {
+                customRenderOptions = options;
+                return 0;
+              },
+              reset() {}
+            };
+            const mockClient = {
+              getChallenge(cb) {
+                cb(null, challenge);
+              }
+            };
+            captcha.render(mockClient, captcha.Flow.DEFAULT, customElement, {
+              appearance: 'interaction-only'
+            });
+            const customScript = [
+              ...customWindow.document.querySelectorAll('script')
+            ].find(s => s.src.match('cloudflare'));
+            const customOnLoad =
+              customWindow[
+                url.parse(customScript.src, true).query.onload
+              ];
+            customOnLoad();
+            expect(customRenderOptions.appearance).to.equal(
+              'interaction-only'
+            );
+            delete global.window;
+          });
+
+          it('should call successCallback when the captcha is solved', function () {
+            const successCallback = sinon.stub();
+            const { window: customWindow } = new JSDOM(
+              '<body><div class="captcha" /></body>'
+            );
+            const customElement =
+              customWindow.document.querySelector('.captcha');
+            global.window = customWindow;
+            let customRenderOptions;
+            customWindow.turnstile = {
+              render(element, options) {
+                customRenderOptions = options;
+                return 0;
+              },
+              reset() {}
+            };
+            const mockClient = {
+              getChallenge(cb) {
+                cb(null, challenge);
+              }
+            };
+            captcha.render(mockClient, captcha.Flow.DEFAULT, customElement, {
+              successCallback
+            });
+            const customScript = [
+              ...customWindow.document.querySelectorAll('script')
+            ].find(s => s.src.match('cloudflare'));
+            const customOnLoad =
+              customWindow[
+                url.parse(customScript.src, true).query.onload
+              ];
+            customOnLoad();
+            const mockToken = 'token xxxxxx';
+            customRenderOptions.callback(mockToken);
+            expect(successCallback.calledOnce).to.be.ok();
+            expect(
+              customElement.querySelector('input[name="captcha"]').value
+            ).to.equal(mockToken);
+            delete global.window;
+          });
         }
 
         it('should clean the value and reset when reloading', function () {


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
As a user of the captcha feature, I noticed that turnstile allows us to pass various configuration options https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configuration-options. It appears that we are already passing light as a default (an example of theme). The addition of appearance to the options for captcha rendering allows us to pass it to turnstile as well. I've included the current default of `always` to ensure consumers do not see a change in appearance. 

### Testing
This can be tested by using the auth0_v2 captcha provider and passing `interaction-only` as the option, for appearance. This will make it so that the widget only appears to user when they need to interact with it.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
