### PR TITLE
Release v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 | Apps using RS256 | No breaking change |
 | Apps using HS256 | `parseHash()` now returns an `invalid_token` error instead of silently succeeding. Must switch to RS256 in the Auth0 Dashboard: Applications → your app → Settings → Advanced Settings → OAuth → JsonWebToken Signature Algorithm → `RS256` |
 
-
 ## [v9.32.0](https://github.com/auth0/auth0.js/tree/v9.32.0) (2026-03-25)
 [Full Changelog](https://github.com/auth0/auth0.js/compare/v9.31.0...v9.32.0)
 


### PR DESCRIPTION
This fixes the release failure (#1631).
**Fixed**
- Security fix: Resolve CVE-2026-42280

**Breaking change**

| Affected | Details |
|---|---|
| Apps using RS256 | No breaking change |
| Apps using HS256 | `parseHash()` now returns an `invalid_token` error instead of silently succeeding. Must switch to RS256 in the Auth0 Dashboard: Applications → your app → Settings → Advanced Settings → OAuth → JsonWebToken Signature Algorithm → `RS256` |
