### PR TITLE
fix(captcha): prevent injection of malicious payloads in challenge.image

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -67,20 +67,26 @@ var defaults = {
   }
 };
 
+function escapeAttr(str) {
+  return String(str || '').replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
 function handleAuth0Provider(element, options, challenge, load) {
-  element.innerHTML = options.templates[challenge.provider](challenge);
-  // Use setAttribute to safely assign challenge.image — avoids HTML injection via innerHTML string concat.
-  // If a custom template is used that omits .captcha-challenge img, src will not be set (by design).
+  var safeChallenge = Object.assign({}, challenge, {
+    image: escapeAttr(challenge.image)
+  });
+  element.innerHTML = options.templates[challenge.provider](safeChallenge);
   var img = element.querySelector('.captcha-challenge img');
   if (img) {
     img.setAttribute('src', challenge.image || '');
   }
-  element
-    .querySelector('.captcha-reload')
-    .addEventListener('click', function (e) {
+  var reloadBtn = element.querySelector('.captcha-reload');
+  if (reloadBtn) {
+    reloadBtn.addEventListener('click', function (e) {
       e.preventDefault();
       load();
     });
+  }
 }
 
 function globalForCaptchaProvider(provider) {

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -33,9 +33,7 @@ var defaults = {
           : 'Solve the formula shown above';
       return (
         '<div class="captcha-challenge">\n' +
-        '  <img src="' +
-        challenge.image +
-        '" />\n' +
+        '  <img src="" />\n' +
         '  <button type="button" class="captcha-reload">↺</button>\n' +
         '</div>\n' +
         '<input type="text" name="captcha"\n' +
@@ -71,6 +69,10 @@ var defaults = {
 
 function handleAuth0Provider(element, options, challenge, load) {
   element.innerHTML = options.templates[challenge.provider](challenge);
+  var img = element.querySelector('.captcha-challenge img');
+  if (img) {
+    img.setAttribute('src', challenge.image || '');
+  }
   element
     .querySelector('.captcha-reload')
     .addEventListener('click', function (e) {

--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -69,6 +69,8 @@ var defaults = {
 
 function handleAuth0Provider(element, options, challenge, load) {
   element.innerHTML = options.templates[challenge.provider](challenge);
+  // Use setAttribute to safely assign challenge.image — avoids HTML injection via innerHTML string concat.
+  // If a custom template is used that omits .captcha-challenge img, src will not be set (by design).
   var img = element.querySelector('.captcha-challenge img');
   if (img) {
     img.setAttribute('src', challenge.image || '');

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -123,6 +123,18 @@ describe('captcha rendering', function () {
       expect(imgEl.src).to.equal(challenges[0].image);
     });
 
+    it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
+      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
+      const el = w.document.querySelector('.captcha');
+      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
+      const mockClient = { getChallenge: cb => cb(null, maliciousChallenge) };
+      captcha.render(mockClient, captcha.Flow.DEFAULT, el, {});
+      const imgEl = el.querySelector('img');
+      expect(imgEl).to.be.ok();
+      expect(imgEl.getAttribute('onerror')).to.equal(null);
+      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+    });
+
     it('should contain an input tag with name captcha', function () {
       const inputEl = element.querySelector('input[name="captcha"]');
       expect(inputEl).to.be.ok();

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -4,6 +4,17 @@ import sinon from 'sinon';
 import captcha from '../../src/web-auth/captcha';
 import expect from 'expect.js';
 
+function assertNoInjection(flow, makeClient) {
+  const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
+  const el = w.document.querySelector('.captcha');
+  const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
+  captcha.render(makeClient(maliciousChallenge), flow, el, {});
+  const imgEl = el.querySelector('img');
+  expect(imgEl).to.be.ok();
+  expect(imgEl.getAttribute('onerror')).to.equal(null);
+  expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+}
+
 describe('captcha rendering', function () {
   describe('when challenge is not required', function () {
     const { window } = new JSDOM('<body><div class="captcha" /></body>');
@@ -124,15 +135,7 @@ describe('captcha rendering', function () {
     });
 
     it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
-      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
-      const el = w.document.querySelector('.captcha');
-      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
-      const mockClient = { getChallenge: cb => cb(null, maliciousChallenge) };
-      captcha.render(mockClient, captcha.Flow.DEFAULT, el, {});
-      const imgEl = el.querySelector('img');
-      expect(imgEl).to.be.ok();
-      expect(imgEl.getAttribute('onerror')).to.equal(null);
-      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+      assertNoInjection(captcha.Flow.DEFAULT, mc => ({ getChallenge: cb => cb(null, mc) }));
     });
 
     it('should contain an input tag with name captcha', function () {
@@ -775,15 +778,7 @@ describe('passwordless captcha rendering', function () {
     });
 
     it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
-      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
-      const el = w.document.querySelector('.captcha');
-      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
-      const mockClient = { passwordless: { getChallenge: cb => cb(null, maliciousChallenge) } };
-      captcha.render(mockClient, captcha.Flow.PASSWORDLESS, el, {});
-      const imgEl = el.querySelector('img');
-      expect(imgEl).to.be.ok();
-      expect(imgEl.getAttribute('onerror')).to.equal(null);
-      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+      assertNoInjection(captcha.Flow.PASSWORDLESS, mc => ({ passwordless: { getChallenge: cb => cb(null, mc) } }));
     });
 
     it('should contain an input tag with name captcha', function () {
@@ -1403,15 +1398,7 @@ describe('password reset captcha rendering', function () {
     });
 
     it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
-      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
-      const el = w.document.querySelector('.captcha');
-      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
-      const mockClient = { dbConnection: { getPasswordResetChallenge: cb => cb(null, maliciousChallenge) } };
-      captcha.render(mockClient, captcha.Flow.PASSWORD_RESET, el, {});
-      const imgEl = el.querySelector('img');
-      expect(imgEl).to.be.ok();
-      expect(imgEl.getAttribute('onerror')).to.equal(null);
-      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+      assertNoInjection(captcha.Flow.PASSWORD_RESET, mc => ({ dbConnection: { getPasswordResetChallenge: cb => cb(null, mc) } }));
     });
 
     it('should contain an input tag with name captcha', function () {

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -774,6 +774,18 @@ describe('passwordless captcha rendering', function () {
       expect(imgEl.src).to.equal(challenges[0].image);
     });
 
+    it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
+      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
+      const el = w.document.querySelector('.captcha');
+      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
+      const mockClient = { passwordless: { getChallenge: cb => cb(null, maliciousChallenge) } };
+      captcha.render(mockClient, captcha.Flow.PASSWORDLESS, el, {});
+      const imgEl = el.querySelector('img');
+      expect(imgEl).to.be.ok();
+      expect(imgEl.getAttribute('onerror')).to.equal(null);
+      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
+    });
+
     it('should contain an input tag with name captcha', function () {
       const inputEl = element.querySelector('input[name="captcha"]');
       expect(inputEl).to.be.ok();
@@ -1388,6 +1400,18 @@ describe('password reset captcha rendering', function () {
     it('should set the image tag', function () {
       const imgEl = element.querySelector('img');
       expect(imgEl.src).to.equal(challenges[0].image);
+    });
+
+    it('should not inject HTML attributes when challenge.image contains a malicious payload', function () {
+      const { window: w } = new JSDOM('<body><div class="captcha" style="display: none;" /></body>');
+      const el = w.document.querySelector('.captcha');
+      const maliciousChallenge = { required: true, provider: 'auth0', image: 'x" onerror="alert(1)" x="' };
+      const mockClient = { dbConnection: { getPasswordResetChallenge: cb => cb(null, maliciousChallenge) } };
+      captcha.render(mockClient, captcha.Flow.PASSWORD_RESET, el, {});
+      const imgEl = el.querySelector('img');
+      expect(imgEl).to.be.ok();
+      expect(imgEl.getAttribute('onerror')).to.equal(null);
+      expect(imgEl.getAttribute('src')).to.equal(maliciousChallenge.image);
     });
 
     it('should contain an input tag with name captcha', function () {


### PR DESCRIPTION
## Fix 

The `auth0` captcha template concatenated `challenge.image` directly into an HTML string assigned to `innerHTML`, allowing attribute injection if the value contained quote characters.

**Fix:** removed `challenge.image` from the template string and set `src` via `img.setAttribute('src', challenge.image || '')` instead - the DOM API encodes the value safely.

**No breaking changes.** Public API, visual output, and custom template overrides are all unaffected.


