### PR TITLE
fix(packaging): add `exports` map so default import works under Vite/Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "type": "module",
   "module": "dist/auth0.min.esm.js",
   "main": "dist/auth0.min.js",
+  "exports": {
+    ".": {
+      "import": "./dist/auth0.min.esm.js",
+      "require": "./dist/auth0.min.js",
+      "default": "./dist/auth0.min.esm.js"
+    },
+    "./dist/*": "./dist/*",
+    "./build/*": "./build/*",
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "plugins",


### PR DESCRIPTION
Fixes #1654.

### Changes

Adds an `exports` field to `package.json` so each module environment resolves `auth0-js` to the correct bundle. No code changes; no `dist/` rebuild; no build/test infrastructure changes.

```json
"exports": {
  ".": {
    "import":  "./dist/auth0.min.esm.js",
    "require": "./dist/auth0.min.js",
    "default": "./dist/auth0.min.esm.js"
  },
  "./dist/*":        "./dist/*",
  "./build/*":       "./build/*",
  "./package.json":  "./package.json"
}
```

**Why this works:**

- `import` condition → ESM bundle. Fixes the bug reported in #1654: Vite/Vitest (and any modern bundler that respects `"type": "module"`) were resolving the package to the UMD `main`, loading it as ESM, finding no top-level `export` statements, and handing consumers `undefined` for the default import. Routing `import` directly at the ESM bundle restores the documented `import auth0 from 'auth0-js'` usage.
- `require` condition → UMD bundle. Jest-style transformers that read `exports` will pick up the UMD file and execute it as CJS, where `exports.X = ...` writes work correctly.
- `default` fallback → ESM bundle for any environment that doesn't match the above conditions.
- `./dist/*` and `./build/*` wildcards preserve deep-path imports (`auth0-js/dist/auth0.min.esm.js` etc.) that some consumers have adopted as a workaround for #1654. Once this lands the workaround is unnecessary, but keeping the wildcards avoids breaking anyone who's still on the workaround.
- `./package.json` is exposed because some tools (TypeScript, bundlers) read it.

### Honest scope

This PR fixes the **ESM consumer path** (the bug in #1654 — the one breaking the documented import). The pure-Node **CJS `require()` path** remains broken on v10 because `"type": "module"` causes Node to load `.js` files as ESM regardless of the `require` condition target, so the UMD bundle's `exports.X = ...` writes still have no effect. Fixing that properly requires renaming the UMD output to `.cjs` (or splitting the build), which is out of scope here. Filing as a separate concern if maintainers want.

Verified on a baseline of v10.0.0 master (pre-PR): `require('auth0-js')` already returns `[Module: null prototype] {}` — so this PR neither fixes nor regresses CJS.

### References

- Bug report with full reproduction: #1654
- README documents `import auth0 from 'auth0-js'` then `new auth0.WebAuth({...})` — the exact pattern broken by v10 packaging.

### Testing

All existing local CI gates green against this branch:

| Gate | Result |
|---|---|
| `npm run lint` | clean |
| `npm run build` | produces all 4 expected artifacts |
| `npm test` | 658 passing |
| `npm run test:es-check:es5` | pass |
| `npm run test:es-check:es2015:module` | pass |

I didn't run `npm run smoke:modern` or the BrowserStack e2e tests — those need toolchain I don't have set up locally. Happy to add coverage if the reviewer suggests a specific gate.

#### Resolution probe (Node 22, ESM consumer)

Against the unmodified v10.0.0:
```
default import: undefined
namespace keys: []
```

Against this branch:
```
default import: { Authentication: [Function], Management: [Function], WebAuth: [Function], version: '10.0.0' }
default.Authentication: function
default.WebAuth: function
```

- [ ] This change adds unit test coverage — *N/A, packaging-only metadata change*
- [ ] This change adds integration test coverage — *N/A, packaging-only metadata change*

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors