### PR TITLE
fix: upgrade js-cookie to v3 with ES5 transpilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "base64-js": "^1.5.1",
         "idtoken-verifier": "^2.2.4",
-        "js-cookie": "^2.2.0",
+        "js-cookie": "^3.0.7",
         "minimist": "^1.2.5",
         "qs": "^6.15.2",
         "superagent": "^10.2.3",
@@ -9774,9 +9774,9 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "base64-js": "^1.5.1",
     "idtoken-verifier": "^2.2.4",
-    "js-cookie": "^2.2.0",
+    "js-cookie": "^3.0.7",
     "minimist": "^1.2.5",
     "qs": "^6.15.2",
     "superagent": "^10.2.3",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -82,7 +82,7 @@ const getPlugins = prod => [
         }
       }]
     ],
-    include: ['src/**', 'node_modules/superagent/**']
+    include: ['src/**', 'node_modules/superagent/**', 'node_modules/js-cookie/**']
   }),
   replace({
     __DEV__: prod ? 'false' : 'true',


### PR DESCRIPTION
Bumps js-cookie to v3.0.7 and adds it to Babel's include list so its modern syntax gets transpiled to ES5, fixing the Compatibility Tests build failure.