### PR TITLE
fix(captcha): call done() after widget reset on reload for recaptcha_…

### DIFF
--- a/src/web-auth/captcha.js
+++ b/src/web-auth/captcha.js
@@ -240,6 +240,7 @@ function handleCaptchaProvider(element, options, challenge) {
   ) {
     setValue();
     window.auth0FCInstance.reset();
+    done();
     return;
   } else if (
     challenge.provider === ARKOSE_PROVIDER &&
@@ -251,6 +252,7 @@ function handleCaptchaProvider(element, options, challenge) {
   } else if (widgetId) {
     setValue();
     globalForCaptchaProvider(challenge.provider).reset(widgetId);
+    done();
     return;
   }
 

--- a/test/web-auth/captcha.test.js
+++ b/test/web-auth/captcha.test.js
@@ -542,6 +542,13 @@ describe('captcha rendering', function () {
           expect(resetted).to.be.ok();
         });
 
+        it('should call done callback when reloading an already-rendered widget', function () {
+          const doneStub = sinon.stub();
+          c.reload(doneStub);
+          expect(doneStub.calledOnce).to.be.ok();
+          expect(resetted).to.be.ok();
+        });
+
         it('should clean the value when there is an error', function () {
           const input = element.querySelector('input[name="captcha"]');
           input.value = 'expired token';


### PR DESCRIPTION
When handleCaptchaProvider takes the early-return paths (widgetId already set, or auth0FCInstance already exists), it resets the widget and returns without calling done(). The ULP form submit handler is gated on done() being invoked, so after a failed first attempt the captcha widget is re-rendered but the form stays permanently blocked — the user solves the captcha but nothing happens.

Call done() before returning in the widgetId and friendly_captcha reset branches. Arkose is intentionally excluded: its done() is fired asynchronously from the onReady callback after arkose.run(), not synchronously on reset.

### Changes

(See diff, ask Claude if you're unsure how to read it)

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All tests and linters described in the [Develop section](https://github.com/auth0/auth0.js#develop) run without errors
